### PR TITLE
fix(dependencies)[-] Revert update of jackson-databind due to missing methods

### DIFF
--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.2</version>
+            <version>2.13.4.2</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
The update to jackson-databind 2.14 leads to MethodNotFoundExceptions in tests.