### PR TITLE
Chore/flatten pom removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ terraform-outputs.json
 terraform-outputs-safe.json
 
 ### Maven generated files ###
-.flattened-pom.xml
 dependency-reduced-pom.xml
 
 

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ DockerHub: https://hub.docker.com/r/tractusx/irs-api
 
 Eclipse Tractus-X product(s) installed within the image:
 
-GitHub: https://github.com/eclipse-tractusx/item-relationship-service
-Project home: https://projects.eclipse.org/projects/automotive.tractusx
-License: Apache License, Version 2.0
-Used base image: eclipse-temurin:19-jre-alpine
+- GitHub: https://github.com/eclipse-tractusx/item-relationship-service
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- License: Apache License, Version 2.0
+- Used base image: eclipse-temurin:19-jre-alpine
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
         <surefire-plugin.version>3.0.0-M8</surefire-plugin.version>
         <jar-plugin.version>3.3.0</jar-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <flatten-plugin.version>1.3.0</flatten-plugin.version>
         <install-plugin.version>3.1.0</install-plugin.version>
     </properties>
 
@@ -154,30 +153,6 @@
         </pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>${flatten-plugin.version}</version>
-                <configuration>
-                    <updatePomFile>true</updatePomFile>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>flatten</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>flatten.clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
Currently the flatten-pom.xml artifact will be ignored by your gitconfig. As I cannot see any usage of the plugin I would recommend removing it to reduce unused plugins / dependencies.