### PR TITLE
PR: Fix of CVE-2022-1471 (snakeyaml)

### DIFF
--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -59,7 +59,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Update snakeyaml manually to avoid vulnerability CVE-2020-13936; can be removed after Spring updates their dependency -->
+        <!-- Update snakeyaml manually to avoid vulnerability CVE-2022-1471; can be removed once spring updates their dependency -->
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>

--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This pull request fix the [ CVE-2022-1471](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1471) in org.yaml.snakeyaml 1.* with the major upgrade to 2.0.

### Changed

IRS-Api POM update of snakeyaml from 1.33 to 2.0

@ds-jkreutzfeld could you please approve actions to verify build / tests are stable with upgrade major version