### PR TITLE
Add publishing step for README file to DockerHub

### DIFF
--- a/.github/workflows/irs-build.yml
+++ b/.github/workflows/irs-build.yml
@@ -15,7 +15,6 @@ on:
       - 'testdata-transform/**'
       - 'testing/**'
       - 'uml-diagrams/**'
-      - 'README.md'
       - 'CHANGELOG.md'
   push:
     branches:
@@ -150,15 +149,25 @@ jobs:
       - name: Push image (DockerHub)
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+          IMAGE_NAMESPACE: tractusx
+          IMAGE_NAME: irs-api
         if: env.DOCKER_HUB_USER != ''
         run: |
-          IMAGE_ID=tractusx/${{ matrix.image }}
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          echo IMAGE_ID=$IMAGE_ID
-          
           docker tag ${{ matrix.image }} $IMAGE_ID:${{ steps.version.outputs.image_tag }}
-          docker push $IMAGE_ID:${{ steps.version.outputs.image_tag }}
+          docker push ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.image_tag }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        env:
+          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+          IMAGE_NAMESPACE: tractusx
+          IMAGE_NAME: irs-api
+        if: env.DOCKER_HUB_USER != '' && github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
 
   trigger-trivy-image-scan:
     needs:

--- a/README.md
+++ b/README.md
@@ -131,8 +131,11 @@ Eclipse Tractus-X product(s) installed within the image:
 
 - GitHub: https://github.com/eclipse-tractusx/item-relationship-service
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- License: Apache License, Version 2.0
-- Used base image: eclipse-temurin:19-jre-alpine
+- Dockerfile: https://github.com/eclipse-tractusx/item-relationship-service/blob/main/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/item-relationship-service/blob/main/LICENSE)
+
+Used base image
+- [eclipse-temurin:19-jre-alpine](https://github.com/adoptium/containers)
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 


### PR DESCRIPTION
This will also push the README file to DockerHub along with the image to describe the project and define the legal terms of usage.