### PR TITLE
chore(helm): Fix config syntax in spring configmap

### DIFF
--- a/charts/irs-helm/CHANGELOG.md
+++ b/charts/irs-helm/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.1] - 2023-04-17
+### Fixed
+- Added missing config keys in the spring config map template
+
 ## [5.1.0] - 2023-04-17
 ### Added
 - New config entry "bpn", add the BPN for the IRS instance there  **(mandatory)**

--- a/charts/irs-helm/Chart.yaml
+++ b/charts/irs-helm/Chart.yaml
@@ -38,7 +38,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.1.0
+version: 5.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/irs-helm/templates/configmap-spring-app-config.yaml
+++ b/charts/irs-helm/templates/configmap-spring-app-config.yaml
@@ -102,13 +102,15 @@ data:
       discovery:
         endpoint: {{ tpl (.Values.discovery.endpoint | default "") . | quote }}
         {{- if .Values.discovery.mockEdcAddress }}
-        {{- tpl (toYaml .Values.discovery.mockEdcAddress) . | nindent 8 }}
+        mockEdcAddress:
+        {{- tpl (toYaml .Values.discovery.mockEdcAddress) . | nindent 10 }}
         {{- end }}
         {{- if .Values.ess.mockEdcResult }}
-        {{- tpl (toYaml .Values.ess.mockEdcResult) . | nindent 8 }}
+        mockEdcResult:
+        {{- tpl (toYaml .Values.ess.mockEdcResult) . | nindent 10 }}
         {{- end }}
         {{- if .Values.ess.mockRecursiveEdcAsset }}
-        {{- tpl (toYaml .Values.ess.mockRecursiveEdcAsset) . | nindent 8 }}
+        mockRecursiveEdcAsset: {{ tpl (.Values.ess.mockRecursiveEdcAsset) . | quote }}
         {{- end }}
     {{- end }}
 


### PR DESCRIPTION
This will add the missing config keys for the new ESS entries in the Spring configmap.