### PR TITLE
chore: no secret scanning by KICS

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -52,6 +52,8 @@ jobs:
           exclude_results: "03df1ef13c69b0ada26fc5bbf35eabca288c5c3c93c0f5d918e41f4951ca8795,8bdf179adec9aee0035149315b63a3f8afd684076358433767758a4a9aeac922" # application-local.yml - local env minio password
           # Exclude accepted queries from the build
           #exclude_queries: ""
+          # No secret scanning
+          disable_secrets: true
 
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard


### PR DESCRIPTION
Yo, yo, listen up, I got a tale to tell,
'Bout how our dev game is ringin' like a bell.
We're on this GitHub grind, pull requests in flight,
But when it comes to scans, man, somethin' ain't right.

Listen, y'all ambitious, that's cool, no debate,
But double, triple scans? Man, let's set this straight.
Veracode, Spotbugs, doing their dance,
But why we got all three for a single PR glance?

Here's my proposition, let's trim it lean,
Drop Veracode and Spotbugs, let CodeQL be the queen.
Security's important, that's the universal rule,
But PR after PR, we lookin' like a fool.

Secret Scan on the PR, that's all we need,
Let the rest run at night, let our main branch breathe.
So what y'all say? Time to make our move,
A bit of fun's essential when we're in the dev groove.

Open to suggestions, let's discuss this play,
But remember, we're here to innovate, not delay.
So drop a comment, let me hear your voice,
Are we cool with CodeQL? Y'all, it's time to make a choice.