### PR TITLE
Tri 1508 update standard to current irs api

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -33,7 +33,7 @@ jobs:
           path: "."
           # Exclude paths or files from scan
           # full-irs is a demonstration and not intended to run in a production environment, it can be excluded
-          exclude_paths: local/deployment/docker-compose.yml,docs/src/api/irs-v1.0.yaml,local/testing/api-tests/irs-api-tests.tavern.yaml,charts/irs-environments/local/*,local/deployment/full-irs
+          exclude_paths: local/deployment/docker-compose.yml,docs/src/api/irs-api.yaml,local/testing/api-tests/irs-api-tests.tavern.yaml,charts/irs-environments/local/*,local/deployment/full-irs
           # Fail on HIGH severity results
           fail_on: high
           # when provided with a directory on output_path

--- a/.github/workflows/swagger-editor-validate.yml
+++ b/.github/workflows/swagger-editor-validate.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Validate OpenAPI definition
         uses: char0n/swagger-editor-validate@v1
         with:
-          definition-file: docs/src/api/irs-v1.0.yaml
+          definition-file: docs/src/api/irs-api.yaml

--- a/docs/src/api/irs-api.yaml
+++ b/docs/src/api/irs-api.yaml
@@ -3,7 +3,7 @@ info:
   description: The API of the Item Relationship Service (IRS) for retrieving item
     graphs along the value chain of CATENA-X partners.
   title: IRS API
-  version: "2.0"
+  version: "2.1.0"
 servers:
   - url: http://localhost:8080
 security:

--- a/irs-api/pom.xml
+++ b/irs-api/pom.xml
@@ -282,7 +282,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>${project.basedir}/../docs/src/api/irs-v1.0.yaml</inputSpec>
+                            <inputSpec>${project.basedir}/../docs/src/api/irs-api.yaml</inputSpec>
                             <generatorName>html</generatorName>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Description
fix(irs-api): fix incorrect versioning in filename of api definition

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
