### PR TITLE
chore(docs): use a relative link to code style settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ cp local/development/commit-msg .git/hooks/commit-msg && chmod 500 .git/hooks/co
 For further information please see https://github.com/hazcod/semantic-commit-hook
 
 ## Code formatting 
-Please use the following code formatter: https://github.com/eclipse-tractusx/item-relationship-service/tree/main/.idea/codeStyles
+Please use the following code formatter: [.idea/codeStyles](.idea/codeStyles)
 
 ## Contact
 


### PR DESCRIPTION
…rdcoded url

The code style settings reside in the repository. So a relative link is sufficient and more flexible than a hard coded URL.

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
