### PR TITLE
chore(foss):[#425] Extract Docker notice to separate file

### DIFF
--- a/.github/workflows/irs-build.yml
+++ b/.github/workflows/irs-build.yml
@@ -174,6 +174,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ./DOCKER_NOTICE.md
 
   trigger-trivy-image-scan:
     if: >-

--- a/DOCKER_NOTICE.md
+++ b/DOCKER_NOTICE.md
@@ -1,0 +1,29 @@
+## Notice for Docker image
+
+This application provides container images for demonstration purposes.
+
+DockerHub: https://hub.docker.com/r/tractusx/irs-api
+
+Eclipse Tractus-X product(s) installed within the image:
+
+Item-Relationship-Service
+
+- GitHub: https://github.com/eclipse-tractusx/item-relationship-service
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Dockerfile: https://github.com/eclipse-tractusx/item-relationship-service/blob/main/Dockerfile
+- Project
+  license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/item-relationship-service/blob/main/LICENSE)
+
+**Used base image**
+
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin
+  images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.

--- a/README.md
+++ b/README.md
@@ -127,31 +127,9 @@ the [NOTICE](https://github.com/eclipse-tractusx/item-relationship-service/blob/
 
 ## Notice for Docker image
 
-This application provides container images for demonstration purposes.
+Bellow you can find the information regarding Docker Notice for this application.
 
-DockerHub: https://hub.docker.com/r/tractusx/irs-api
-
-Eclipse Tractus-X product(s) installed within the image:
-
-- GitHub: https://github.com/eclipse-tractusx/item-relationship-service
-- Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Dockerfile: https://github.com/eclipse-tractusx/item-relationship-service/blob/main/Dockerfile
-- Project
-  license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/item-relationship-service/blob/main/LICENSE)
-
-**Used base image**
-
-- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
-- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
-- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
-- Additional information about the Eclipse Temurin
-  images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
-
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
-from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
-
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
-with any relevant licenses for all software contained within.
+- [Item Relationship Service](./DOCKER_NOTICE.md)
 
 ## Contact
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
- Moved Docker Notice to dedicated File `DOCKER_NOTICE.md`
- Adjusted docker image publishing to include only this docker notice file

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
