### PR TITLE
Feature/536 fix handling of conflict response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 ## [Unreleased]
 ### Changed
 
-- EdcPolicyDefinitionService, EdcContractDefinitionService and EdcAssetService return existing resource if it exists in
-  EDC
+- EdcPolicyDefinitionService, EdcContractDefinitionService and EdcAssetService return throw AlreadyExist exceptions when Conflict is returned from EDC
 - Added AssetAdministrationShellDescriptor specificAssetIds support for externalSubjectId required for data provisioning
 
 

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/EdcAssetService.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/EdcAssetService.java
@@ -102,7 +102,7 @@ public class EdcAssetService {
             }
         } catch (HttpClientErrorException e) {
             if (e.getStatusCode().value() == HttpStatus.CONFLICT.value()) {
-                throw new EdcAssetAlreadyExistsException("asset already exists in the EDC");
+                throw new EdcAssetAlreadyExistsException("asset already exists in the EDC", e);
             }
             throw new CreateEdcAssetException(e);
         }

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/EdcAssetService.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/EdcAssetService.java
@@ -35,10 +35,12 @@ import org.eclipse.tractusx.irs.edc.client.asset.model.NotificationMethod;
 import org.eclipse.tractusx.irs.edc.client.asset.model.NotificationType;
 import org.eclipse.tractusx.irs.edc.client.asset.model.exception.CreateEdcAssetException;
 import org.eclipse.tractusx.irs.edc.client.asset.model.exception.DeleteEdcAssetException;
+import org.eclipse.tractusx.irs.edc.client.asset.model.exception.EdcAssetAlreadyExistsException;
 import org.eclipse.tractusx.irs.edc.client.transformer.EdcTransformer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -95,15 +97,13 @@ public class EdcAssetService {
                     transformedPayload.toString(), String.class);
             final HttpStatusCode responseCode = createEdcDataAssetResponse.getStatusCode();
 
-            if (responseCode.value() == HttpStatus.CONFLICT.value()) {
-                log.info("{} asset already exists in the EDC", request.getId());
-                return request.getId();
-            }
-
             if (responseCode.value() == HttpStatus.OK.value()) {
                 return request.getId();
             }
-        } catch (RestClientException e) {
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode().value() == HttpStatus.CONFLICT.value()) {
+                throw new EdcAssetAlreadyExistsException("asset already exists in the EDC");
+            }
             throw new CreateEdcAssetException(e);
         }
         throw new CreateEdcAssetException("Failed to create asset %s".formatted(request.getId()));
@@ -127,11 +127,10 @@ public class EdcAssetService {
             final NotificationMethod notificationMethod, final NotificationType notificationType) {
         final String assetId = UUID.randomUUID().toString();
         final Map<String, Object> properties = Map.of(ASSET_CREATION_PROPERTY_DESCRIPTION, assetName,
-                ASSET_CREATION_PROPERTY_CONTENT_TYPE, DEFAULT_CONTENT_TYPE,
-                ASSET_CREATION_PROPERTY_POLICY_ID, DEFAULT_POLICY_ID, ASSET_CREATION_PROPERTY_TYPE,
-                notificationType.getValue(), ASSET_CREATION_PROPERTY_NOTIFICATION_TYPE,
-                notificationType.getValue(), ASSET_CREATION_PROPERTY_NOTIFICATION_METHOD,
-                notificationMethod.getValue());
+                ASSET_CREATION_PROPERTY_CONTENT_TYPE, DEFAULT_CONTENT_TYPE, ASSET_CREATION_PROPERTY_POLICY_ID,
+                DEFAULT_POLICY_ID, ASSET_CREATION_PROPERTY_TYPE, notificationType.getValue(),
+                ASSET_CREATION_PROPERTY_NOTIFICATION_TYPE, notificationType.getValue(),
+                ASSET_CREATION_PROPERTY_NOTIFICATION_METHOD, notificationMethod.getValue());
 
         final DataAddress dataAddress = DataAddress.Builder.newInstance()
                                                            .type(HTTP_DATA)
@@ -152,8 +151,8 @@ public class EdcAssetService {
     }
 
     private Asset createDtrAssetRequest(final String assetId, final String baseUrl) {
-        final Map<String, Object> properties = Map.of(ASSET_CREATION_PROPERTY_DESCRIPTION, "Digital Twin Registry Asset", ASSET_CREATION_PROPERTY_TYPE,
-                "data.core.digitalTwinRegistry");
+        final Map<String, Object> properties = Map.of(ASSET_CREATION_PROPERTY_DESCRIPTION,
+                "Digital Twin Registry Asset", ASSET_CREATION_PROPERTY_TYPE, "data.core.digitalTwinRegistry");
 
         final DataAddress dataAddress = DataAddress.Builder.newInstance()
                                                            .type("DataAddress")

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/model/exception/EdcAssetAlreadyExistsException.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/model/exception/EdcAssetAlreadyExistsException.java
@@ -25,7 +25,7 @@ package org.eclipse.tractusx.irs.edc.client.asset.model.exception;
  */
 
 public class EdcAssetAlreadyExistsException extends RuntimeException {
-    public EdcAssetAlreadyExistsException(final String message) {
-        super(message);
+    public EdcAssetAlreadyExistsException(final String message, final Throwable exception) {
+        super(message, exception);
     }
 }

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/model/exception/EdcAssetAlreadyExistsException.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/model/exception/EdcAssetAlreadyExistsException.java
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2022,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.irs.edc.client.asset.model.exception;
+
+/**
+ * EdcAssetAlreadyExistsException used when asset already exists
+ */
+
+public class EdcAssetAlreadyExistsException extends RuntimeException {
+    public EdcAssetAlreadyExistsException(final String message) {
+        super(message);
+    }
+}

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/model/exception/EdcAssetAlreadyExistsException.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/model/exception/EdcAssetAlreadyExistsException.java
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/exception/EdcContractDefinitionAlreadyExists.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/exception/EdcContractDefinitionAlreadyExists.java
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/exception/EdcContractDefinitionAlreadyExists.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/exception/EdcContractDefinitionAlreadyExists.java
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2022,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.irs.edc.client.contract.model.exception;
+
+/**
+ * EdcContractDefinitionAlreadyExists used when contract definition already exists
+ */
+
+public class EdcContractDefinitionAlreadyExists extends RuntimeException {
+    public EdcContractDefinitionAlreadyExists(final String message) {
+        super(message);
+    }
+}

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/exception/EdcContractDefinitionAlreadyExists.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/exception/EdcContractDefinitionAlreadyExists.java
@@ -25,7 +25,7 @@ package org.eclipse.tractusx.irs.edc.client.contract.model.exception;
  */
 
 public class EdcContractDefinitionAlreadyExists extends RuntimeException {
-    public EdcContractDefinitionAlreadyExists(final String message) {
-        super(message);
+    public EdcContractDefinitionAlreadyExists(final String message, final Throwable exception) {
+        super(message, exception);
     }
 }

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/service/EdcContractDefinitionService.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/service/EdcContractDefinitionService.java
@@ -74,7 +74,7 @@ public class EdcContractDefinitionService {
                     "Failed to create EDC contract definition for %s asset id".formatted(assetId));
         } catch (HttpClientErrorException e) {
             if (e.getStatusCode().value() == HttpStatus.CONFLICT.value()) {
-                throw new EdcContractDefinitionAlreadyExists("Contract definition already exists in the EDC");
+                throw new EdcContractDefinitionAlreadyExists("Contract definition already exists in the EDC", e);
             }
             log.error(
                     "Failed to create edc contract definition for {} notification asset and {} policy definition id. Reason: ",

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/model/exception/EdcPolicyDefinitionAlreadyExists.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/model/exception/EdcPolicyDefinitionAlreadyExists.java
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2022,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.irs.edc.client.policy.model.exception;
+
+/**
+ * EdcPolicyDefinitionAlreadyExists used when policy already exists
+ */
+
+public class EdcPolicyDefinitionAlreadyExists extends RuntimeException {
+    public EdcPolicyDefinitionAlreadyExists(final String message) {
+        super(message);
+    }
+}

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/model/exception/EdcPolicyDefinitionAlreadyExists.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/model/exception/EdcPolicyDefinitionAlreadyExists.java
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/model/exception/EdcPolicyDefinitionAlreadyExists.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/model/exception/EdcPolicyDefinitionAlreadyExists.java
@@ -25,7 +25,7 @@ package org.eclipse.tractusx.irs.edc.client.policy.model.exception;
  */
 
 public class EdcPolicyDefinitionAlreadyExists extends RuntimeException {
-    public EdcPolicyDefinitionAlreadyExists(final String message) {
-        super(message);
+    public EdcPolicyDefinitionAlreadyExists(final String message, final Throwable exception) {
+        super(message, exception);
     }
 }

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/service/EdcPolicyDefinitionService.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/service/EdcPolicyDefinitionService.java
@@ -85,7 +85,7 @@ public class EdcPolicyDefinitionService {
         } catch (HttpClientErrorException e) {
             log.error("Failed to create EDC policy definition. Reason: ", e);
             if (e.getStatusCode().value() == HttpStatus.CONFLICT.value()) {
-                throw new EdcPolicyDefinitionAlreadyExists("Policy definition already exists in the EDC");
+                throw new EdcPolicyDefinitionAlreadyExists("Policy definition already exists in the EDC", e);
             }
             throw new CreateEdcPolicyDefinitionException(e);
         }


### PR DESCRIPTION

## Description
### Changed
- EdcPolicyDefinitionService, EdcContractDefinitionService and EdcAssetService return throw AlreadyExist exceptions when Conflict is returned from EDC