### PR TITLE
fix: update docs for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - Added missing @context values in edc asset creation. eclipse-tractusx/traceability-foss#978
 - Switch to `dct:type` `https://w3id.org/catenax/taxonomy#` for notification asset creation. eclipse-tractusx/traceability-foss#978
 - Shells in Job response will contain all submodel descriptors returned by provider, instead filtered by aspect-type parameter. #510
+- Updated contributing, notice, and readme files for TRG 7 #681
 
 ## Added
 
@@ -29,6 +30,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - Integration Test Policy Store API Unhappy Path. #519
 - Support for SingleLevelUsageAsPlanned. #470
 - Documentation to describe the delegate process. #470
+- Added file for CC BY 4.0 license for TRG 7 #681
 
 ## [5.1.4] - 2024-05-27
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,16 @@ Thanks for your interest in this project.
 
 # Table of Contents
 1. [Project description](#project-description)
-2. [Developer resources](#developer-resources)
-3. [Eclipse Development Process](#eclipse-development-process)
-4. [Eclipse Contributor Agreement](#eclipse-contributor-agreement)
-5. [Code of Conduct](#code-of-conduct)
-6. [General contribution to the project](#general-contribution-to-the-project)
-7. [Contributing as a Consultant](#contributing-as-a-consultant)
-8. [Contributing as a Developer](#contributing-as-a-developer)
-9. [Contact](#contact)
+2. [Project licenses](#project-licenses)
+3. [Terms of Use](#terms-of-use)
+4. [Developer resources](#developer-resources)
+5. [Eclipse Development Process](#eclipse-development-process)
+6. [Eclipse Contributor Agreement](#eclipse-contributor-agreement)
+7. [Code of Conduct](#code-of-conduct)
+8. [General contribution to the project](#general-contribution-to-the-project)
+9. [Contributing as a Consultant](#contributing-as-a-consultant)
+10. [Contributing as a Developer](#contributing-as-a-developer)
+11. [Contact](#contact)
 
 ## Project Description
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 
 [![Apache 2 License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/eclipse-tractusx/item-relationship-service/blob/main/LICENSE)  
+[![Non-code license: CC BY 4.0](https://img.shields.io/badge/Non--code_license-CC%20BY%204.0-orange.svg)](https://github.com/eclipse-tractusx/item-relationship-service/blob/main/LICENSE_non-code)
 [![Build](https://github.com/eclipse-tractusx/item-relationship-service/actions/workflows/irs-build.yml/badge.svg)](https://github.com/eclipse-tractusx/item-relationship-service/actions/workflows/irs-build.yml)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=eclipse-tractusx_item-relationship-service&metric=coverage)](https://sonarcloud.io/summary/new_code?id=eclipse-tractusx_item-relationship-service)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=eclipse-tractusx_item-relationship-service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=eclipse-tractusx_item-relationship-service)


### PR DESCRIPTION
## Description

- updated docs which have become inconsistent since #691 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files