### PR TITLE
fix(policy-store): [#trace-foss-970] return rightOperand without odrl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 
 ### Fixed
 
--  Fixed ESS Investigation job processing not starting #579
+- Fixed ESS Investigation job processing not starting #579
+- Policy store API returns 'rightOperand' without 'odrl:' prefix now (see traceability-foss/issues/970).
 
 ### Changed
 

--- a/docs/concept/#333-Policy-hub-concept/#333-policy-hub-concept.md
+++ b/docs/concept/#333-Policy-hub-concept/#333-policy-hub-concept.md
@@ -108,14 +108,14 @@ sequenceDiagram
 
 ### Policy Validation 
 
-| PolicyContentDefinition Request        | PolicyTemplate  Response | Policy              | Description                                                                                                                                               | 
-|----------------------------------------|--------------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------| 
-| PolicyType (Usage/Access)              | action(use, access)      | action(use, access) | Mappring of correct type                                                                                                                                  |  
-| ConstraintOperand (And/Or)             | odrl:and/:or             |odrl:and/:or| Logical Operand to use AND and OR is supported                                                                                                            |
-| Constraints.Key                        | leftOperand              | leftOperand         |                     |                                                                                                                                      |
-| Constraints.Operator (Equals, In, ...) | operator(eq,in,neq, ...) | operator  (eq,in,neq, ...)          |    |                                                                                                                                                       |  
-| Constraints.Value Static               | rightOperand             | rightOperand        | For static value check right operand for dynamic value check if Policy.rightOperand.value is in PolicyTemplate.rightOperand.atrributes.key.possibleValues | 
-| Constraints.Value Attributes           | rightOperand @attributes | rightOperand        | Dynamic value check if Policy.rightOperand.value is in PolicyTemplate.rightOperand.atrributes.key.possibleValues                                          | 
+| PolicyContentDefinition Request        | PolicyTemplate  Response | Policy                     | Description                                                                                                                                               | 
+|----------------------------------------|--------------------------|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------| 
+| PolicyType (Usage/Access)              | action(use, access)      | action(use, access)        | Mapping of correct type                                                                                                                                   |  
+| ConstraintOperand (And/Or)             | odrl:and/:or             | odrl:and/:or               | Logical Operand to use AND and OR is supported                                                                                                            |
+| Constraints.Key                        | leftOperand              | leftOperand                |                                                                                                                                                           |                                                                                                                                      |
+| Constraints.Operator (Equals, In, ...) | operator(eq,in,neq, ...) | operator  (eq,in,neq, ...) |                                                                                                                                                           |                                                                                                                                                       |  
+| Constraints.Value Static               | rightOperand             | rightOperand               | For static value check right operand for dynamic value check if Policy.rightOperand.value is in PolicyTemplate.rightOperand.atrributes.key.possibleValues | 
+| Constraints.Value Attributes           | rightOperand @attributes | rightOperand               | Dynamic value check if Policy.rightOperand.value is in PolicyTemplate.rightOperand.atrributes.key.possibleValues                                          | 
 
 ### Detailed error message 
 

--- a/docs/src/api/irs-api.yaml
+++ b/docs/src/api/irs-api.yaml
@@ -827,11 +827,11 @@ paths:
                           - leftOperand: Membership
                             operator:
                               '@id': eq
-                            odrl:rightOperand: active
+                            rightOperand: active
                           - leftOperand: PURPOSE
                             operator:
                               '@id': eq
-                            odrl:rightOperand: ID 3.1 Trace
+                            rightOperand: ID 3.1 Trace
                           or: null
                 BPNA1234567890DF: []
               schema:

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Constraint.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Constraint.java
@@ -39,13 +39,14 @@ import lombok.NoArgsConstructor;
 public class Constraint {
 
     @Schema(implementation = String.class, example = "string")
-    @JsonAlias({"odrl:leftOperand"})
+    @JsonAlias({ "odrl:leftOperand" })
     private String leftOperand;
     @JsonAlias("odrl:operator")
     @Schema
     private Operator operator;
     @Schema(implementation = String.class, example = "string")
-    @JsonProperty("odrl:rightOperand")
+    @JsonAlias("odrl:rightOperand")
+    @JsonProperty("rightOperand")
     private String rightOperand;
 
 }

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Constraint.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/policy/Constraint.java
@@ -24,7 +24,6 @@
 package org.eclipse.tractusx.irs.edc.client.policy;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -39,14 +38,13 @@ import lombok.NoArgsConstructor;
 public class Constraint {
 
     @Schema(implementation = String.class, example = "string")
-    @JsonAlias({ "odrl:leftOperand" })
+    @JsonAlias("odrl:leftOperand")
     private String leftOperand;
     @JsonAlias("odrl:operator")
     @Schema
     private Operator operator;
     @Schema(implementation = String.class, example = "string")
     @JsonAlias("odrl:rightOperand")
-    @JsonProperty("rightOperand")
     private String rightOperand;
 
 }

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/policy/ConstraintTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/policy/ConstraintTest.java
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (c) 2022,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.irs.edc.client.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConstraintTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+    }
+
+    @Test
+    void canReadPermissionsWithDifferentRightOperandAttributeNames() throws JsonProcessingException {
+
+        final List<Permission> permissions = mapper.readerForListOf(Permission.class).readValue("""
+                [
+                  {
+                    "action": "use",
+                    "constraint": {
+                      "and": [
+                        {
+                          "leftOperand": "Membership",
+                          "operator": {
+                            "@id": "eq"
+                          },
+                          "odrl:rightOperand": "active"
+                        },
+                        {
+                          "leftOperand": "PURPOSE",
+                          "operator": {
+                            "@id": "eq"
+                          },
+                          "rightOperand": "ID 3.1 Trace"
+                        }
+                      ],
+                      "or": null
+                    }
+                  }
+                ]
+                """);
+
+        assertThat(permissions).isNotEmpty();
+        assertThat(permissions.stream()
+                              .map(p -> p.getConstraint().getAnd())
+                              .flatMap(Collection::stream)
+                              .map(Constraint::getRightOperand)).containsExactlyInAnyOrder("active", "ID 3.1 Trace");
+    }
+
+}

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/models/PolicyResponse.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/models/PolicyResponse.java
@@ -56,14 +56,14 @@ public record PolicyResponse(OffsetDateTime validUntil, Payload payload) {
                                                       "operator": {
                                                           "@id": "eq"
                                                       },
-                                                      "odrl:rightOperand": "active"
+                                                      "rightOperand": "active"
                                                   },
                                                   {
                                                       "leftOperand": "PURPOSE",
                                                       "operator": {
                                                           "@id": "eq"
                                                       },
-                                                      "odrl:rightOperand": "ID 3.1 Trace"
+                                                      "rightOperand": "ID 3.1 Trace"
                                                   }
                                               ],
                                               "or": null


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
- https://github.com/eclipse-tractusx/traceability-foss/issues/970

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
