### PR TITLE
chore(trivy):[#xxx] trivy fix mentioned in the Community Office Hour

### DIFF
--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -58,9 +58,11 @@ jobs:
           image-ref: "localhost:5000/irs-api:testing"
           format: "sarif"
           output: "trivy-results2.sarif"
-          exit-code: "1"
+          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
           severity: "CRITICAL,HIGH"
           trivyignores: .config/.trivyignore
+          limit-severities-for-sarif: true
+
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 
 - Fixed ESS Investigation job processing not starting #579
 - Policy store API returns 'rightOperand' without 'odrl:' prefix now (see traceability-foss/issues/970).
+- Fixed trivy workflow to fail only on CRITICAL, HIGH (according to https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/949/files).
 
 ### Changed
 


### PR DESCRIPTION
see https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/949/files

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

- Fix Trivy workflow to fail only on CRITICAL, HIGH according to https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/949/files (as it was mentioned in the Community Office Hour 2024-06-28)


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
