### PR TITLE
chore(charts): update bitnami/common to 2.x.x

### DIFF
--- a/charts/item-relationship-service/CHANGELOG.md
+++ b/charts/item-relationship-service/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.2.0] - 2024-07-03
+## [7.2.1] - 2024-07-10
 - Update bitnami/common to 2.x.x
 
+## [7.2.0] - 2024-07-03
 ### Changed
 - Update IRS version to 5.2.0
 

--- a/charts/item-relationship-service/CHANGELOG.md
+++ b/charts/item-relationship-service/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [7.2.0] - 2024-07-03
-
+- Update bitnami/common to 2.x.x
 
 ### Changed
 - Update IRS version to 5.2.0

--- a/charts/item-relationship-service/Chart.yaml
+++ b/charts/item-relationship-service/Chart.yaml
@@ -35,7 +35,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 7.2.0
+version: 7.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -44,7 +44,7 @@ appVersion: "5.2.0"
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: 1.x.x
+    version: 2.x.x
   - name: minio
     repository: https://charts.min.io/
     version: 5.0.1


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
- Updated bitnami/common helm dependency to 2.x.x to match other charts of the umbrella chart

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
