### PR TITLE
chore: update spring boot to version 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 
 ### Changed
 
+- Updated Spring Boot to version 3.3 #380
 - Improved policy store API input validation. #528
 - Extended datamodel of EdcPolicyPermissionConstraint to include andConstraints
 - Marked createAccessPolicy requests with deprecation mark.

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
-maven/mavencentral/ch.qos.logback/logback-classic/1.4.14, EPL-1.0 AND LGPL-2.1-only, approved, #15230
-maven/mavencentral/ch.qos.logback/logback-core/1.4.14, EPL-1.0 AND LGPL-2.1-only, approved, #15209
+maven/mavencentral/ch.qos.logback/logback-classic/1.5.6, EPL-1.0 AND LGPL-2.1-only, approved, #15279
+maven/mavencentral/ch.qos.logback/logback-core/1.5.6, EPL-1.0 AND LGPL-2.1-only, approved, #15210
 maven/mavencentral/com.aayushatharva.brotli4j/brotli4j/1.11.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.aayushatharva.brotli4j/native-linux-aarch64/1.11.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.aayushatharva.brotli4j/native-linux-x86_64/1.11.0, Apache-2.0, approved, clearlydefined
@@ -11,27 +11,25 @@ maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, 
 maven/mavencentral/com.carrotsearch.thirdparty/simple-xml-safe/2.7.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.eatthepath/fast-uuid/0.2.0, MIT, approved, clearlydefined
 maven/mavencentral/com.ethlo.time/itu/1.8.0, Apache-2.0, approved, #12927
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.4, Apache-2.0, approved, #15260
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.1, Apache-2.0, approved, #11606
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.4, , approved, #15194
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.1, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.1, Apache-2.0 AND MIT, approved, #11602
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.1, , approved, #13665
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.1, Apache-2.0, approved, #7934
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.4, Apache-2.0, approved, #15199
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.1, Apache-2.0, approved, #11605
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.1, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.3, Apache-2.0, approved, #15207
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.4, Apache-2.0, approved, #15207
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.15.4, Apache-2.0, approved, #15211
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.17.1, Apache-2.0, approved, #13669
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.16.2, Apache-2.0, approved, #15198
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.15.4, Apache-2.0, approved, #15281
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.4, Apache-2.0, approved, #15189
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.15.4, Apache-2.0, approved, #15219
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.17.1, Apache-2.0, approved, #14161
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.17.1, Apache-2.0, approved, #15117
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.17.1, Apache-2.0, approved, #14160
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.17.1, Apache-2.0, approved, #15122
 maven/mavencentral/com.fasterxml/classmate/1.5.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.fasterxml/classmate/1.7.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.ben-manes.caffeine/caffeine/3.1.8, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.github.docker-java/docker-java-api/3.3.0, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
-maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15251
-maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.0, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.mifmif/generex/1.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.scopt/scopt_2.13/3.7.1, MIT, approved, clearlydefined
@@ -52,11 +50,9 @@ maven/mavencentral/com.networknt/json-schema-validator/1.4.0, Apache-2.0 AND Uni
 maven/mavencentral/com.nimbusds/content-type/2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/lang-tag/1.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/9.43.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/9.43.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.softwaremill.quicklens/quicklens_2.13/1.9.3, Apache-2.0, approved, #9635
-maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
-maven/mavencentral/com.squareup.okhttp3/okhttp/4.10.0, Apache-2.0 AND MPL-2.0, approved, #3057
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #15227
 maven/mavencentral/com.squareup.okio/okio-jvm/3.5.0, Apache-2.0, approved, #9851
 maven/mavencentral/com.squareup.okio/okio/3.6.0, Apache-2.0, approved, #11155
@@ -68,7 +64,6 @@ maven/mavencentral/com.typesafe/config/1.4.2, Apache-2.0, approved, clearlydefin
 maven/mavencentral/com.vaadin.external.google/android-json/0.0.20131108.vaadin1, Apache-2.0, approved, CQ21310
 maven/mavencentral/com.vdurmont/semver4j/3.1.0, MIT, approved, clearlydefined
 maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
-maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
 maven/mavencentral/commons-codec/commons-codec/1.16.1, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9157
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, #15185
 maven/mavencentral/commons-digester/commons-digester/2.1, Apache-2.0, approved, clearlydefined
@@ -134,49 +129,48 @@ maven/mavencentral/io.github.resilience4j/resilience4j-retry/2.1.0, Apache-2.0, 
 maven/mavencentral/io.github.resilience4j/resilience4j-spring-boot3/2.1.0, Apache-2.0, approved, #10913
 maven/mavencentral/io.github.resilience4j/resilience4j-spring6/2.1.0, Apache-2.0, approved, #10915
 maven/mavencentral/io.github.resilience4j/resilience4j-timelimiter/2.1.0, Apache-2.0, approved, #10166
-maven/mavencentral/io.micrometer/micrometer-commons/1.11.11, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
-maven/mavencentral/io.micrometer/micrometer-core/1.11.11, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
-maven/mavencentral/io.micrometer/micrometer-observation/1.11.11, Apache-2.0, approved, #9242
+maven/mavencentral/io.micrometer/micrometer-commons/1.13.1, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14826
+maven/mavencentral/io.micrometer/micrometer-core/1.11.4, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
+maven/mavencentral/io.micrometer/micrometer-core/1.13.1, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14827
+maven/mavencentral/io.micrometer/micrometer-jakarta9/1.13.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.micrometer/micrometer-observation/1.13.1, Apache-2.0, approved, #14829
 maven/mavencentral/io.micrometer/micrometer-registry-prometheus/1.11.4, Apache-2.0, approved, #9805
 maven/mavencentral/io.minio/minio/8.5.9, Apache-2.0, approved, #9097
 maven/mavencentral/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.21.Final, Apache-2.0, approved, #9622
 maven/mavencentral/io.netty.incubator/netty-incubator-transport-native-io_uring/0.0.21.Final, GPL-2.0-only WITH Linux-syscall-note OR MIT AND Apache-2.0 AND MIT, approved, #9649
-maven/mavencentral/io.netty/netty-buffer/4.1.109.Final, Apache-2.0, approved, CQ21842
-maven/mavencentral/io.netty/netty-codec-dns/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http2/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-mqtt/4.1.109.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
-maven/mavencentral/io.netty/netty-codec-socks/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-common/4.1.109.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
-maven/mavencentral/io.netty/netty-handler-proxy/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-handler/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.109.Final, Apache-2.0, approved, #6367
-maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.109.Final, Apache-2.0, approved, #7004
-maven/mavencentral/io.netty/netty-resolver-dns/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-buffer/4.1.111.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.netty/netty-codec-dns/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http2/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-mqtt/4.1.111.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
+maven/mavencentral/io.netty/netty-codec-socks/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-common/4.1.111.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
+maven/mavencentral/io.netty/netty-handler-proxy/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-handler/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.111.Final, Apache-2.0, approved, #6367
+maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.111.Final, Apache-2.0, approved, #7004
+maven/mavencentral/io.netty/netty-resolver-dns/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-tcnative-boringssl-static/2.0.65.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
 maven/mavencentral/io.netty/netty-tcnative-classes/2.0.65.Final, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.109.Final, Apache-2.0, approved, #6366
-maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport/4.1.109.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.25.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.111.Final, Apache-2.0, approved, #6366
+maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport/4.1.111.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.25.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.37.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.37.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.pebbletemplates/pebble/3.2.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.rest-assured/json-path/5.3.2, Apache-2.0, approved, #9261
 maven/mavencentral/io.rest-assured/json-path/5.4.0, Apache-2.0, approved, #12042
-maven/mavencentral/io.rest-assured/rest-assured-common/5.3.2, Apache-2.0, approved, #9264
 maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, Apache-2.0, approved, #12039
 maven/mavencentral/io.rest-assured/rest-assured/5.4.0, Apache-2.0, approved, #15190
-maven/mavencentral/io.rest-assured/xml-path/5.3.2, Apache-2.0, approved, #9267
 maven/mavencentral/io.rest-assured/xml-path/5.4.0, Apache-2.0, approved, #12038
 maven/mavencentral/io.suzaku/boopickle_2.13/1.3.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.20, Apache-2.0, approved, #5947
@@ -192,46 +186,45 @@ maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-onl
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.2, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/javax.jms/javax.jms-api/2.0.1, CDDL-1.1 OR GPL-2.0 WITH Classpath-exception-2.0, approved, #1516
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.13, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.4, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy/1.12.21, Apache-2.0 AND BSD-3-Clause, approved, #1811
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.13, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.12, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.17, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.17, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.datafaker/datafaker/1.9.0, Apache-2.0, approved, #8797
 maven/mavencentral/net.debasishg/redisclient_2.13/3.42, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.java.dev.jna/jna/5.12.1, Apache-2.0 OR LGPL-2.1-or-later, approved, #3217
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #15196
 maven/mavencentral/net.javacrumbs.json-unit/json-unit-assertj/3.2.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/3.2.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.javacrumbs.json-unit/json-unit-json-path/3.2.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.jodah/typetools/0.6.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.minidev/accessors-smart/2.4.11, Apache-2.0, approved, #7515
 maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.minidev/json-smart/2.4.11, Apache-2.0, approved, #3288
 maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
 maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-compress/1.26.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #13288
 maven/mavencentral/org.apache.commons/commons-compress/1.26.1, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #13288
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apache.commons/commons-pool2/2.11.1, Apache-2.0, approved, CQ23795
+maven/mavencentral/org.apache.commons/commons-lang3/3.14.0, Apache-2.0, approved, #11677
+maven/mavencentral/org.apache.commons/commons-pool2/2.12.0, Apache-2.0 AND LicenseRef-Public-Domain, approved, #10843
 maven/mavencentral/org.apache.groovy/groovy-json/4.0.21, Apache-2.0, approved, #7411
 maven/mavencentral/org.apache.groovy/groovy-xml/4.0.21, Apache-2.0, approved, #10179
 maven/mavencentral/org.apache.groovy/groovy/4.0.21, Apache-2.0 AND BSD-3-Clause AND MIT, approved, #1742
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.13, Apache-2.0, approved, #15248
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.apache.httpcomponents/httpmime/4.5.13, Apache-2.0, approved, CQ11718
-maven/mavencentral/org.apache.logging.log4j/log4j-api/2.20.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apache.logging.log4j/log4j-core/2.20.0, Apache-2.0 AND (Apache-2.0 AND LGPL-2.0-or-later), approved, #8809
-maven/mavencentral/org.apache.logging.log4j/log4j-jul/2.20.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apache.logging.log4j/log4j-slf4j2-impl/2.20.0, Apache-2.0, approved, #8801
-maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.20.0, Apache-2.0, approved, #8799
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.20, Apache-2.0 AND (EPL-2.0 OR (GPL-2.0 WITH Classpath-exception-2.0)) AND CDDL-1.0 AND (CDDL-1.1 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND EPL-2.0, approved, #15195
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.20, Apache-2.0, approved, #6997
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.20, Apache-2.0, approved, #7920
+maven/mavencentral/org.apache.logging.log4j/log4j-api/2.23.1, Apache-2.0, approved, #13368
+maven/mavencentral/org.apache.logging.log4j/log4j-core/2.23.1, Apache-2.0 AND (Apache-2.0 AND LGPL-2.0-or-later), approved, #14737
+maven/mavencentral/org.apache.logging.log4j/log4j-jul/2.23.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.logging.log4j/log4j-slf4j2-impl/2.23.1, Apache-2.0, restricted, clearlydefined
+maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.23.1, Apache-2.0, approved, #15121
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.25, Apache-2.0 AND (EPL-2.0 OR (GPL-2.0 WITH Classpath-exception-2.0)) AND CDDL-1.0 AND (CDDL-1.1 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND EPL-2.0, approved, #15195
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.25, Apache-2.0, approved, #6997
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.25, Apache-2.0, approved, #7920
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.aspectj/aspectjweaver/1.9.22, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #15252
-maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
+maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, #14178
+maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78, MIT, approved, #14434
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14433
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78, MIT, approved, #14435
@@ -315,17 +308,18 @@ maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only wit
 maven/mavencentral/org.hamcrest/hamcrest-core/2.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, CC0-1.0, approved, #15259
+maven/mavencentral/org.hdrhistogram/HdrHistogram/2.2.2, BSD-2-Clause AND CC0-1.0 AND CC0-1.0, approved, #14828
 maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.1.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss.logging/jboss-logging/3.4.3.Final, Apache-2.0, approved, CQ21255
 maven/mavencentral/org.jboss.logging/jboss-logging/3.5.3.Final, Apache-2.0, approved, #9471
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.22, Apache-2.0, approved, #8910
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.9.0, Apache-2.0, approved, #14186
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.9.24, Apache-2.0, approved, #14186
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.21, Apache-2.0, approved, #8807
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.22, Apache-2.0, approved, #8807
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.9.24, Apache-2.0, approved, #14188
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.21, Apache-2.0, approved, #8919
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.22, Apache-2.0, approved, #8875
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.9.24, Apache-2.0, approved, #14185
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.8.21, Apache-2.0, approved, #8865
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.8.22, Apache-2.0, approved, #8865
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.9.24, Apache-2.0, approved, #11827
 maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clearlydefined
@@ -333,30 +327,22 @@ maven/mavencentral/org.jodd/jodd-lagarto/6.0.6, BSD-2-Clause, approved, clearlyd
 maven/mavencentral/org.jodd/jodd-util/6.1.0, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/org.jsoup/jsoup/1.17.2, MIT AND Apache-2.0, approved, #11785
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.2, EPL-2.0, approved, #9714
-maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.3, EPL-2.0, approved, #3133
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.2, EPL-2.0, approved, #9711
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.2, EPL-2.0, approved, #3125
-maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.3, EPL-2.0, approved, #3125
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.2, EPL-2.0, approved, #15250
-maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.3, EPL-2.0, approved, #3134
 maven/mavencentral/org.junit.jupiter/junit-jupiter/5.10.2, EPL-2.0, approved, #15197
-maven/mavencentral/org.junit.jupiter/junit-jupiter/5.9.3, EPL-2.0, approved, #6972
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.2, EPL-2.0, approved, #9715
-maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.3, EPL-2.0, approved, #3130
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.2, EPL-2.0, approved, #9709
-maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.3, EPL-2.0, approved, #3128
 maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.2, EPL-2.0, approved, #15216
 maven/mavencentral/org.junit.platform/junit-platform-suite-api/1.10.2, EPL-2.0, approved, #15240
 maven/mavencentral/org.junit.platform/junit-platform-suite-commons/1.10.2, EPL-2.0, approved, #15214
 maven/mavencentral/org.junit.platform/junit-platform-suite-engine/1.10.2, EPL-2.0, approved, #15258
 maven/mavencentral/org.junit.platform/junit-platform-suite/1.10.2, EPL-2.0, approved, #14183
 maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, CC0-1.0, approved, #15280
-maven/mavencentral/org.mockito/mockito-core/5.3.1, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7925
-maven/mavencentral/org.mockito/mockito-junit-jupiter/5.3.1, MIT, approved, clearlydefined
+maven/mavencentral/org.mockito/mockito-core/5.11.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #13505
+maven/mavencentral/org.mockito/mockito-junit-jupiter/5.11.0, MIT, approved, #13504
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
-maven/mavencentral/org.ow2.asm/asm/9.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
 maven/mavencentral/org.projectlombok/lombok/1.18.32, MIT, approved, #15192
 maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
@@ -372,53 +358,54 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.13, MIT, approved, #5915
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.2.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.1.11, Apache-2.0, approved, #9348
-maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.1.11, Apache-2.0, approved, #9342
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.11, Apache-2.0, approved, #9341
-maven/mavencentral/org.springframework.boot/spring-boot-configuration-metadata/3.1.11, Apache-2.0, approved, #11032
-maven/mavencentral/org.springframework.boot/spring-boot-properties-migrator/3.1.11, Apache-2.0, approved, #10675
-maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.1.11, Apache-2.0, approved, #9344
-maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.1.11, Apache-2.0, approved, #9338
-maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.11, Apache-2.0, approved, #9336
-maven/mavencentral/org.springframework.boot/spring-boot-starter-log4j2/3.1.11, Apache-2.0, approved, #8800
-maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.1.11, Apache-2.0, approved, #9343
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.1.11, Apache-2.0, approved, #8806
-maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.1.11, Apache-2.0, approved, #9337
-maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.1.11, Apache-2.0, approved, #9353
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.1.11, Apache-2.0, approved, #9351
-maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.1.11, Apache-2.0, approved, #9335
-maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.1.11, Apache-2.0, approved, #9347
-maven/mavencentral/org.springframework.boot/spring-boot-starter/3.1.11, Apache-2.0, approved, #9349
-maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.1.11, Apache-2.0, approved, #9339
-maven/mavencentral/org.springframework.boot/spring-boot-test/3.1.11, Apache-2.0, approved, #9346
-maven/mavencentral/org.springframework.boot/spring-boot/3.1.11, Apache-2.0, approved, #9352
-maven/mavencentral/org.springframework.data/spring-data-commons/3.1.11, Apache-2.0, approved, #8805
-maven/mavencentral/org.springframework.security/spring-security-config/6.1.9, Apache-2.0, approved, #9736
-maven/mavencentral/org.springframework.security/spring-security-core/6.1.9, Apache-2.0, approved, #9801
-maven/mavencentral/org.springframework.security/spring-security-crypto/6.1.9, Apache-2.0 AND ISC, approved, #9735
-maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.1.9, Apache-2.0, approved, #9740
-maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.1.9, Apache-2.0, approved, #9741
-maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.1.9, Apache-2.0, approved, #9345
-maven/mavencentral/org.springframework.security/spring-security-test/6.1.9, Apache-2.0, approved, #10674
-maven/mavencentral/org.springframework.security/spring-security-web/6.1.9, Apache-2.0, approved, #9800
-maven/mavencentral/org.springframework/spring-aop/6.0.19, Apache-2.0, approved, #5940
-maven/mavencentral/org.springframework/spring-beans/6.0.19, Apache-2.0, approved, #5937
-maven/mavencentral/org.springframework/spring-context/6.0.19, Apache-2.0, approved, #5936
-maven/mavencentral/org.springframework/spring-core/6.0.19, Apache-2.0 AND BSD-3-Clause, approved, #5948
-maven/mavencentral/org.springframework/spring-expression/6.0.19, Apache-2.0, approved, #3284
-maven/mavencentral/org.springframework/spring-jcl/6.0.19, Apache-2.0, approved, #3283
-maven/mavencentral/org.springframework/spring-test/6.0.19, Apache-2.0, approved, #7003
-maven/mavencentral/org.springframework/spring-web/6.0.19, Apache-2.0, approved, #5942
-maven/mavencentral/org.springframework/spring-webmvc/6.0.19, Apache-2.0, approved, #5944
-maven/mavencentral/org.testcontainers/junit-jupiter/1.18.3, MIT, approved, #7941
+maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-configuration-metadata/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-properties-migrator/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-log4j2/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-test/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot/3.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.data/spring-data-commons/3.3.1, Apache-2.0, approved, #15116
+maven/mavencentral/org.springframework.security/spring-security-config/6.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.security/spring-security-core/6.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.security/spring-security-crypto/6.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.security/spring-security-test/6.3.1, , restricted, clearlydefined
+maven/mavencentral/org.springframework.security/spring-security-web/6.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework/spring-aop/6.1.10, Apache-2.0, approved, #15221
+maven/mavencentral/org.springframework/spring-beans/6.1.10, Apache-2.0, approved, #15213
+maven/mavencentral/org.springframework/spring-beans/6.1.9, Apache-2.0, approved, #15213
+maven/mavencentral/org.springframework/spring-context/6.1.10, Apache-2.0, approved, #15261
+maven/mavencentral/org.springframework/spring-core/6.1.10, Apache-2.0 AND BSD-3-Clause, approved, #15206
+maven/mavencentral/org.springframework/spring-expression/6.1.10, Apache-2.0, approved, #15264
+maven/mavencentral/org.springframework/spring-jcl/6.1.10, Apache-2.0, approved, #15266
+maven/mavencentral/org.springframework/spring-test/6.1.10, Apache-2.0, approved, #15265
+maven/mavencentral/org.springframework/spring-web/6.1.10, Apache-2.0, approved, #15188
+maven/mavencentral/org.springframework/spring-webmvc/6.1.10, Apache-2.0, approved, #15182
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.7, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/testcontainers/1.18.3, MIT, approved, #7938
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.8, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/testcontainers/1.19.7, MIT, approved, #15203
+maven/mavencentral/org.testcontainers/testcontainers/1.19.8, MIT, approved, #15203
 maven/mavencentral/org.typelevel/spire-macros_2.13/0.17.0, MIT, approved, clearlydefined
 maven/mavencentral/org.unbescape/unbescape/1.1.6.RELEASE, Apache-2.0, approved, CQ18904
 maven/mavencentral/org.webjars/swagger-ui/5.2.0, Apache-2.0, approved, #10221
 maven/mavencentral/org.wiremock/wiremock-standalone/3.5.2, MIT AND Apache-2.0, approved, #14258
 maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.5, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
 maven/mavencentral/org.xmlunit/xmlunit-core/2.10.0, Apache-2.0, approved, #14590
-maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
+maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/docs/src/api/irs-api.yaml
+++ b/docs/src/api/irs-api.yaml
@@ -394,8 +394,6 @@ paths:
         schema:
           type: string
           format: uuid
-          maxLength: 36
-          minLength: 36
       - description: "\\<true\\> Return job with current processed item graph. \\\
           <false\\> Return job with item graph if job is in state COMPLETED, otherwise\
           \ job."
@@ -478,8 +476,6 @@ paths:
         schema:
           type: string
           format: uuid
-          maxLength: 36
-          minLength: 36
       responses:
         "200":
           content:
@@ -598,8 +594,6 @@ paths:
         schema:
           type: string
           format: uuid
-          maxLength: 36
-          minLength: 36
       responses:
         "200":
           content:
@@ -663,8 +657,6 @@ paths:
         schema:
           type: string
           format: uuid
-          maxLength: 36
-          minLength: 36
       responses:
         "200":
           content:
@@ -729,8 +721,6 @@ paths:
         schema:
           type: string
           format: uuid
-          maxLength: 36
-          minLength: 36
       - description: Id of the batch.
         example: 4bce40b8-64c7-41bf-9ca3-e9432c7fef98
         in: path
@@ -739,8 +729,6 @@ paths:
         schema:
           type: string
           format: uuid
-          maxLength: 36
-          minLength: 36
       responses:
         "200":
           content:

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/BatchController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/BatchController.java
@@ -38,7 +38,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.irs.IrsApplication;
@@ -198,9 +197,8 @@ public class BatchController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public BatchOrderResponse getBatchOrder(
             @Parameter(description = "Id of the order.", schema = @Schema(implementation = UUID.class),
-                       name = "orderId", example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Size(
-                    min = IrsAppConstants.JOB_ID_SIZE,
-                    max = IrsAppConstants.JOB_ID_SIZE) @Valid @PathVariable final UUID orderId) {
+                       name = "orderId",
+                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID orderId) {
         return queryBatchService.findOrderById(orderId);
     }
 
@@ -244,13 +242,11 @@ public class BatchController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public BatchResponse getBatch(
             @Parameter(description = "Id of the order.", schema = @Schema(implementation = UUID.class),
-                       name = "orderId", example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Size(
-                    min = IrsAppConstants.JOB_ID_SIZE,
-                    max = IrsAppConstants.JOB_ID_SIZE) @Valid @PathVariable final UUID orderId,
+                       name = "orderId",
+                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID orderId,
             @Parameter(description = "Id of the batch.", schema = @Schema(implementation = UUID.class),
-                       name = "batchId", example = "4bce40b8-64c7-41bf-9ca3-e9432c7fef98") @Size(
-                    min = IrsAppConstants.JOB_ID_SIZE,
-                    max = IrsAppConstants.JOB_ID_SIZE) @Valid @PathVariable final UUID batchId) {
+                       name = "batchId",
+                       example = "4bce40b8-64c7-41bf-9ca3-e9432c7fef98") @Valid @PathVariable final UUID batchId) {
         return queryBatchService.findBatchById(orderId, batchId);
     }
 
@@ -294,9 +290,8 @@ public class BatchController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public BatchOrderResponse cancelBatchOrder(
             @Parameter(description = "Id of the order.", schema = @Schema(implementation = UUID.class),
-                       name = "orderId", example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Size(
-                    min = IrsAppConstants.JOB_ID_SIZE,
-                    max = IrsAppConstants.JOB_ID_SIZE) @Valid @PathVariable final UUID orderId) {
+                       name = "orderId",
+                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID orderId) {
         cancelBatchProcessingService.cancelNotFinishedJobsInBatchOrder(orderId);
         return queryBatchService.findOrderById(orderId);
     }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/BatchController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/BatchController.java
@@ -197,8 +197,8 @@ public class BatchController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public BatchOrderResponse getBatchOrder(
             @Parameter(description = "Id of the order.", schema = @Schema(implementation = UUID.class),
-                       name = "orderId",
-                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID orderId) {
+                       name = "orderId", example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable(
+                    "orderId") final UUID orderId) {
         return queryBatchService.findOrderById(orderId);
     }
 
@@ -242,11 +242,11 @@ public class BatchController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public BatchResponse getBatch(
             @Parameter(description = "Id of the order.", schema = @Schema(implementation = UUID.class),
-                       name = "orderId",
-                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID orderId,
+                       name = "orderId", example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable(
+                    "orderId") final UUID orderId,
             @Parameter(description = "Id of the batch.", schema = @Schema(implementation = UUID.class),
-                       name = "batchId",
-                       example = "4bce40b8-64c7-41bf-9ca3-e9432c7fef98") @Valid @PathVariable final UUID batchId) {
+                       name = "batchId", example = "4bce40b8-64c7-41bf-9ca3-e9432c7fef98") @Valid @PathVariable(
+                    "batchId") final UUID batchId) {
         return queryBatchService.findBatchById(orderId, batchId);
     }
 
@@ -290,8 +290,8 @@ public class BatchController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public BatchOrderResponse cancelBatchOrder(
             @Parameter(description = "Id of the order.", schema = @Schema(implementation = UUID.class),
-                       name = "orderId",
-                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID orderId) {
+                       name = "orderId", example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable(
+                    "orderId") final UUID orderId) {
         cancelBatchProcessingService.cancelNotFinishedJobsInBatchOrder(orderId);
         return queryBatchService.findOrderById(orderId);
     }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsController.java
@@ -175,10 +175,11 @@ public class IrsController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public ResponseEntity<Jobs> getJobById(
             @Parameter(description = "Id of the job.", schema = @Schema(implementation = UUID.class), name = "id",
-                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID id, @Parameter(
-            description = "\\<true\\> Return job with current processed item graph. \\<false\\> Return job with item graph if job is in state COMPLETED, otherwise job.") @Schema(
-            implementation = Boolean.class, defaultValue = "true") @RequestParam(value = "returnUncompletedJob",
-                                                                                 required = false) final boolean returnUncompletedJob) {
+                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable("id") final UUID id,
+            @Parameter(
+                    description = "\\<true\\> Return job with current processed item graph. \\<false\\> Return job with item graph if job is in state COMPLETED, otherwise job.") @Schema(
+                    implementation = Boolean.class, defaultValue = "true") @RequestParam(value = "returnUncompletedJob",
+                                                                                         required = false) final boolean returnUncompletedJob) {
         final Jobs job = itemJobService.getJobForJobId(id, returnUncompletedJob);
         if (job.getJob().getState().equals(JobState.RUNNING)) {
             return ResponseEntity.status(HttpStatus.PARTIAL_CONTENT).body(job);
@@ -225,7 +226,7 @@ public class IrsController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public Job cancelJobByJobId(
             @Parameter(description = "Id of the job.", schema = @Schema(implementation = UUID.class), name = "id",
-                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID id) {
+                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable("id") final UUID id) {
 
         return this.itemJobService.cancelJobById(id);
     }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/controllers/IrsController.java
@@ -42,7 +42,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.irs.IrsApplication;
@@ -176,12 +175,10 @@ public class IrsController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public ResponseEntity<Jobs> getJobById(
             @Parameter(description = "Id of the job.", schema = @Schema(implementation = UUID.class), name = "id",
-                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Size(min = IrsAppConstants.JOB_ID_SIZE,
-                                                                               max = IrsAppConstants.JOB_ID_SIZE) @Valid @PathVariable final UUID id,
-            @Parameter(
-                    description = "\\<true\\> Return job with current processed item graph. \\<false\\> Return job with item graph if job is in state COMPLETED, otherwise job.") @Schema(
-                    implementation = Boolean.class, defaultValue = "true") @RequestParam(value = "returnUncompletedJob",
-                                                                                         required = false) final boolean returnUncompletedJob) {
+                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID id, @Parameter(
+            description = "\\<true\\> Return job with current processed item graph. \\<false\\> Return job with item graph if job is in state COMPLETED, otherwise job.") @Schema(
+            implementation = Boolean.class, defaultValue = "true") @RequestParam(value = "returnUncompletedJob",
+                                                                                 required = false) final boolean returnUncompletedJob) {
         final Jobs job = itemJobService.getJobForJobId(id, returnUncompletedJob);
         if (job.getJob().getState().equals(JobState.RUNNING)) {
             return ResponseEntity.status(HttpStatus.PARTIAL_CONTENT).body(job);
@@ -228,8 +225,7 @@ public class IrsController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public Job cancelJobByJobId(
             @Parameter(description = "Id of the job.", schema = @Schema(implementation = UUID.class), name = "id",
-                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Size(min = IrsAppConstants.JOB_ID_SIZE,
-                                                                               max = IrsAppConstants.JOB_ID_SIZE) @Valid @PathVariable final UUID id) {
+                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID id) {
 
         return this.itemJobService.cancelJobById(id);
     }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/EssController.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/ess/controller/EssController.java
@@ -152,7 +152,7 @@ class EssController {
     @PreAuthorize("hasAnyAuthority('" + IrsRoles.ADMIN_IRS + "', '" + IrsRoles.VIEW_IRS + "')")
     public Jobs getBPNInvestigation(
             @Parameter(description = "Id of the job.", schema = @Schema(implementation = UUID.class), name = "id",
-                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable final UUID id) {
+                       example = "6c311d29-5753-46d4-b32c-19b918ea93b0") @Valid @PathVariable("id") final UUID id) {
         return essService.getIrsJob(id.toString());
     }
 

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubFacade.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/semanticshub/SemanticsHubFacade.java
@@ -52,7 +52,7 @@ public class SemanticsHubFacade {
      * @param urn of the model
      * @return Json Schema
      */
-    @Cacheable(value = SEMANTICS_HUB_CACHE_NAME, key = "#urn")
+    @Cacheable(value = SEMANTICS_HUB_CACHE_NAME, key = "#p0")
     public String getModelJsonSchema(final String urn) throws SchemaNotFoundException {
         log.info("Retrieving json schema for urn {}", urn);
         return this.semanticsHubClient.getModelJsonSchema(urn);

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/util/CustomKeyValueProvider.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/util/CustomKeyValueProvider.java
@@ -37,17 +37,15 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class CustomKeyValueProvider extends DefaultClientRequestObservationConvention {
-    private static final String GLOBAL_ASSET_ID_REGEX = "urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
+    private static final String GLOBAL_ASSET_ID_REGEX = "(urn:uuid:)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
 
     @Override
     public @NotNull KeyValues getLowCardinalityKeyValues(@NotNull final ClientRequestObservationContext context) {
-
         KeyValues keyValues = KeyValues.of(clientName(context), outcome(context), method(context), status(context));
 
         final KeyValue uri = uri(context);
-
-        keyValues = keyValues.and(
-                KeyValue.of(uri.getKey(), uri.getValue().replaceAll(GLOBAL_ASSET_ID_REGEX, "{uuid}")));
+        final String uriWithUuidReplaced = uri.getValue().replaceAll(GLOBAL_ASSET_ID_REGEX, "{uuid}");
+        keyValues = keyValues.and(KeyValue.of(uri.getKey(), uriWithUuidReplaced));
 
         return keyValues;
     }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/util/CustomKeyValueProvider.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/util/CustomKeyValueProvider.java
@@ -42,13 +42,15 @@ public class CustomKeyValueProvider extends DefaultClientRequestObservationConve
     @Override
     public @NotNull KeyValues getLowCardinalityKeyValues(@NotNull final ClientRequestObservationContext context) {
 
-        final KeyValues keyValues = KeyValues.empty();
+        KeyValues keyValues = KeyValues.empty();
 
-        keyValues.and(KeyValues.of(clientName(context), outcome(context), method(context), status(context)));
+        keyValues = keyValues.and(
+                KeyValues.of(clientName(context), outcome(context), method(context), status(context)));
 
         final KeyValue uri = uri(context);
 
-        keyValues.and(KeyValue.of(uri.getKey(), uri.getValue().replaceAll(GLOBAL_ASSET_ID_REGEX, "{uuid}")));
+        keyValues = keyValues.and(
+                KeyValue.of(uri.getKey(), uri.getValue().replaceAll(GLOBAL_ASSET_ID_REGEX, "{uuid}")));
 
         return keyValues;
     }

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/util/CustomKeyValueProvider.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/util/CustomKeyValueProvider.java
@@ -42,10 +42,7 @@ public class CustomKeyValueProvider extends DefaultClientRequestObservationConve
     @Override
     public @NotNull KeyValues getLowCardinalityKeyValues(@NotNull final ClientRequestObservationContext context) {
 
-        KeyValues keyValues = KeyValues.empty();
-
-        keyValues = keyValues.and(
-                KeyValues.of(clientName(context), outcome(context), method(context), status(context)));
+        KeyValues keyValues = KeyValues.of(clientName(context), outcome(context), method(context), status(context));
 
         final KeyValue uri = uri(context);
 

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/controllers/BatchControllerTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/controllers/BatchControllerTest.java
@@ -165,4 +165,17 @@ class BatchControllerTest extends ControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(content().string(containsString(orderId.toString())));
     }
+
+    @Test
+    void shouldReturnBadRequestWhenUuidMalformed() throws Exception {
+        authenticateWith(IrsRoles.VIEW_IRS);
+
+        final String orderId = "12345-1348-13-abcd-a-b-z-g-h";
+        final String orderId2 = "zc311d29-5753-46d4-b32c-19b918ea93b0";
+        final String orderId3 = "ac311d29-5753-4-d4-b32c-19b918ea93b0";
+
+        this.mockMvc.perform(put("/irs/orders/" + orderId)).andExpect(status().isBadRequest());
+        this.mockMvc.perform(put("/irs/orders/" + orderId2)).andExpect(status().isBadRequest());
+        this.mockMvc.perform(put("/irs/orders/" + orderId3)).andExpect(status().isBadRequest());
+    }
 }

--- a/irs-api/src/test/java/org/eclipse/tractusx/irs/util/CustomKeyValueProviderTest.java
+++ b/irs-api/src/test/java/org/eclipse/tractusx/irs/util/CustomKeyValueProviderTest.java
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (c) 2022,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.irs.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+
+class CustomKeyValueProviderTest {
+
+    @Test
+    void shouldReplaceUuidCorrectlyInUri() {
+        // arrange
+        final UUID uuid = UUID.randomUUID();
+        final String uriString = "http://localhost:8080/irs/jobs/" + uuid;
+        final MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, uriString);
+        final ClientRequestObservationContext context = new ClientRequestObservationContext(request);
+        context.setUriTemplate(uriString);
+
+        // act
+        final CustomKeyValueProvider provider = new CustomKeyValueProvider();
+        final KeyValues keyValues = provider.getLowCardinalityKeyValues(context);
+        final Optional<KeyValue> returnedUri = keyValues.stream()
+                                                        .filter(keyValue -> keyValue.getKey().equals("uri"))
+                                                        .findFirst();
+
+        // assert
+        assertThat(returnedUri).isPresent();
+        assertThat(returnedUri.get().getValue()).doesNotContain(uuid.toString()).contains("{uuid}");
+    }
+
+}

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/config/DefaultAcceptedPoliciesConfig.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/config/DefaultAcceptedPoliciesConfig.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -44,6 +45,7 @@ public class DefaultAcceptedPoliciesConfig {
      */
     @Data
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class AcceptedPolicy {
         private String leftOperand;
         private String operator;

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/controllers/PolicyStoreController.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/controllers/PolicyStoreController.java
@@ -191,7 +191,7 @@ public class PolicyStoreController {
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("hasAuthority('" + IrsRoles.ADMIN_IRS + "')")
     public Map<String, List<PolicyResponse>> getPolicies(//
-            @RequestParam(required = false) //
+            @RequestParam(required = false, name = "businessPartnerNumbers") //
             @ValidListOfBusinessPartnerNumbers //
             @Parameter(description = "List of business partner numbers.") //
             final List<String> businessPartnerNumbers //

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <irs-registry-client.version>2.1.4</irs-registry-client.version>
 
         <!-- Dependencies -->
-        <springboot.version>3.1.11</springboot.version>
+        <springboot.version>3.3.0</springboot.version>
         <springdoc.version>2.2.0</springdoc.version>
         <micrometer.version>1.11.4</micrometer.version>
         <datafaker.version>1.9.0</datafaker.version>
@@ -178,6 +178,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler-plugin.version}</version>
+                    <configuration>
+                        <parameters>true</parameters>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -178,9 +178,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler-plugin.version}</version>
-                    <configuration>
-                        <parameters>true</parameters>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <irs-registry-client.version>2.1.5-SNAPSHOT</irs-registry-client.version>
 
         <!-- Dependencies -->
-        <springboot.version>3.3.0</springboot.version>
+        <springboot.version>3.3.1</springboot.version>
         <springdoc.version>2.2.0</springdoc.version>
         <micrometer.version>1.11.4</micrometer.version>
         <datafaker.version>1.9.0</datafaker.version>


### PR DESCRIPTION
## Description

This PR addresses #380.

- The `CustomUriTagProvider` class has been renamed to `CustomKeyValueProvider`. This is due to the fact that Spring 3.2 dropped some classes and the code now uses their replacement. This replacement class no longer uses the `Tag` class, but the `KeyValue` and `KeyValues` classes.

- Starting with Spring Framework 6.1 (Spring Boot 3.3.1 brings version 6.1.10), Spring's `LocalVariableTableParameterNameDiscoverer` can no longer be used to discover parameter names, see https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention. This required some changes in the code:

  - Methods in the rest controller classes now explicitly include parameter names in the `@PathVariable` and `@RequestParameter` annotations, otherwise the parameters are not recognized. In the methods that were changed, the (apparently generally superfluous) validation of passed UUIDs using `@Size` has been removed since it caused errors. The OpenAPI spec has been adapted accordingly. An integration test has been added in `BatchControllerTest` to verify that this removal does not allow requests with malformed UUIDs.

  - When using the `@Cacheable` annotation (e.g. in `SemanticsHubFacade`), it is no longer possible to use a SpEl expression like `"#urn"` to specify the caching key. Instead, the code now needs a SpEl-Expression like `"#p0"`, see https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/cache/annotation/Cacheable.html#key().

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
