### PR TITLE
fix(exception-handling): [#xxx] fix error message for request trying …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 
 ## [Unreleased]
 
+### Added
+
+
+### Fixed
+
+
+### Changed
+
+- Replaced technical error message when trying to delete the configured default policy with a user-friendly message.  
+
+
 ## [5.2.0] - 2024-07-03
 
 ### Fixed

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/services/PolicyStoreService.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/services/PolicyStoreService.java
@@ -197,9 +197,8 @@ public class PolicyStoreService implements AcceptedPoliciesProvider {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                     "Policy with id '%s' not found".formatted(policyId));
         } else if (bpnsContainingPolicyId.stream().noneMatch(StringUtils::isNotEmpty)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                    ("A configured default policy cannot be deleted. "
-                            + "It can be overridden by defining a default policy via the API instead."));
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "A configured default policy cannot be deleted. "
+                    + "It can be overridden by defining a default policy via the API instead.");
         } else {
             try {
                 log.info("Deleting policy with id {}", policyId);

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/services/PolicyStoreService.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/services/PolicyStoreService.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 
 import jakarta.json.JsonObject;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.tractusx.irs.edc.client.policy.AcceptedPoliciesProvider;
 import org.eclipse.tractusx.irs.edc.client.policy.AcceptedPolicy;
 import org.eclipse.tractusx.irs.edc.client.policy.Constraint;
@@ -188,19 +189,24 @@ public class PolicyStoreService implements AcceptedPoliciesProvider {
     }
 
     public void deletePolicy(final String policyId) {
+
         log.info("Getting all policies to find correct BPN");
         final List<String> bpnsContainingPolicyId = PolicyHelper.findBpnsByPolicyId(getAllStoredPolicies(), policyId);
 
         if (bpnsContainingPolicyId.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                     "Policy with id '%s' not found".formatted(policyId));
-        }
-
-        try {
-            log.info("Deleting policy with id {}", policyId);
-            bpnsContainingPolicyId.forEach(bpn -> persistence.delete(bpn, policyId));
-        } catch (final PolicyStoreException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), e);
+        } else if (bpnsContainingPolicyId.stream().noneMatch(StringUtils::isNotEmpty)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    ("A configured default policy cannot be deleted. "
+                            + "It can be overridden by defining a default policy via the API instead."));
+        } else {
+            try {
+                log.info("Deleting policy with id {}", policyId);
+                bpnsContainingPolicyId.forEach(bpn -> persistence.delete(bpn, policyId));
+            } catch (final PolicyStoreException e) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), e);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

When someone tries to delete a configured default policy there was a technical error message which is not very helpful:
```
{
	"statusCode": "BAD_REQUEST",
	"error": "object name must be a non-empty string.",
	"messages": null
}
```

This PR improves the message in the following way:
```
{
	"statusCode": "BAD_REQUEST",
	"error": "Bad Request",
	"messages": [
		"A configured default policy cannot be deleted. It can be overridden by defining a default policy via the API instead. (errorRef: 8e83da14-9d8b-4dda-aee3-06aad002066b)"
	]
}
```


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
