### PR TITLE
feature: eclipse-tractusx/traceability-foss#1190 add getContractDefin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 
 ### Added
 
+- Added get and delete functionality for contract definitions eclipse-tractusx/traceability-foss#1190
+
 ### Fixed
 
 - Access and Usage Policy Validation flow correction. #757
@@ -19,6 +21,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 ### Changed
 
 - Replaced technical error message when trying to delete the configured default policy with a user-friendly message.
+- Renamed EdcCreateContractDefinitionRequest to EdcContractDefinition because it's used for both get and post eclipse-tractusx/traceability-foss#1190
 
 
 ## [5.2.0] - 2024-07-03

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/model/EdcContext.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/asset/model/EdcContext.java
@@ -19,8 +19,13 @@
  ********************************************************************************/
 package org.eclipse.tractusx.irs.edc.client.asset.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
 
@@ -30,7 +35,12 @@ import lombok.extern.jackson.Jacksonized;
 
 @ToString
 @Builder
+@AllArgsConstructor
 @Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
+@NoArgsConstructor
+@Getter
+@Setter
 public class EdcContext {
     @JsonProperty("edc")
     private String edc;

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/EdcContractDefinition.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/EdcContractDefinition.java
@@ -20,17 +20,25 @@
 package org.eclipse.tractusx.irs.edc.client.contract.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import org.eclipse.tractusx.irs.edc.client.asset.model.EdcContext;
 
 /**
- * EdcCreateContractDefinitionRequest used for creation of contract
+ * EdcCreateContractDefinitionRequest used for creating and receiving contract definitions
  */
 
 @ToString
 @Builder
-public class EdcCreateContractDefinitionRequest {
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class EdcContractDefinition {
 
     @JsonProperty("@context")
     private EdcContext edcContext;

--- a/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/EdcContractDefinitionCriteria.java
+++ b/irs-edc-client/src/main/java/org/eclipse/tractusx/irs/edc/client/contract/model/EdcContractDefinitionCriteria.java
@@ -20,8 +20,11 @@
 package org.eclipse.tractusx.irs.edc.client.contract.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -31,6 +34,9 @@ import lombok.ToString;
 @ToString
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
 public class EdcContractDefinitionCriteria {
 
     @JsonProperty("@type")

--- a/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/contract/service/EdcContractDefinitionServiceTest.java
+++ b/irs-edc-client/src/test/java/org/eclipse/tractusx/irs/edc/client/contract/service/EdcContractDefinitionServiceTest.java
@@ -22,10 +22,16 @@ package org.eclipse.tractusx.irs.edc.client.contract.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.tractusx.irs.edc.client.EdcConfiguration;
-import org.eclipse.tractusx.irs.edc.client.contract.model.EdcCreateContractDefinitionRequest;
+import org.eclipse.tractusx.irs.edc.client.contract.model.EdcContractDefinition;
 import org.eclipse.tractusx.irs.edc.client.contract.model.exception.CreateEdcContractDefinitionException;
 import org.eclipse.tractusx.irs.edc.client.contract.model.exception.EdcContractDefinitionAlreadyExists;
 import org.json.JSONException;
@@ -33,15 +39,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.type.TypeFactory;
 
 @ExtendWith(MockitoExtension.class)
 class EdcContractDefinitionServiceTest {
@@ -71,7 +80,7 @@ class EdcContractDefinitionServiceTest {
         String contractId = "ContractId1";
 
         // when
-        EdcCreateContractDefinitionRequest request = service.createContractDefinitionRequest(assetId, policyId,
+        EdcContractDefinition request = service.createContractDefinitionRequest(assetId, policyId,
                 contractId);
 
         // then
@@ -102,7 +111,7 @@ class EdcContractDefinitionServiceTest {
         when(endpointConfig.getContractDefinition()).thenReturn("/management/v2/contractdefinitions");
         String assetId = "Asset1";
         String policyId = "Policy1";
-        when(restTemplate.postForEntity(any(String.class), any(EdcCreateContractDefinitionRequest.class),
+        when(restTemplate.postForEntity(any(String.class), any(EdcContractDefinition.class),
                 any())).thenReturn(ResponseEntity.ok("test"));
 
         String result = service.createContractDefinition(assetId, policyId);
@@ -118,7 +127,7 @@ class EdcContractDefinitionServiceTest {
         when(endpointConfig.getContractDefinition()).thenReturn("/management/v2/contractdefinitions");
         final String assetId = "Asset1";
         final String policyId = "Policy1";
-        when(restTemplate.postForEntity(any(String.class), any(EdcCreateContractDefinitionRequest.class),
+        when(restTemplate.postForEntity(any(String.class), any(EdcContractDefinition.class),
                 any())).thenThrow(
                 HttpClientErrorException.create("Surprise", HttpStatus.CONFLICT, "", null, null, null));
 
@@ -134,7 +143,7 @@ class EdcContractDefinitionServiceTest {
         when(endpointConfig.getContractDefinition()).thenReturn("/management/v2/contractdefinitions");
         String assetId = "Asset1";
         String policyId = "Policy1";
-        when(restTemplate.postForEntity(any(String.class), any(EdcCreateContractDefinitionRequest.class),
+        when(restTemplate.postForEntity(any(String.class), any(EdcContractDefinition.class),
                 any())).thenReturn(ResponseEntity.status(HttpStatus.BAD_REQUEST.value()).build());
 
         assertThrows(CreateEdcContractDefinitionException.class,
@@ -149,11 +158,72 @@ class EdcContractDefinitionServiceTest {
         when(endpointConfig.getContractDefinition()).thenReturn("/management/v2/contractdefinitions");
         String assetId = "Asset1";
         String policyId = "Policy1";
-        when(restTemplate.postForEntity(any(String.class), any(EdcCreateContractDefinitionRequest.class),
+        when(restTemplate.postForEntity(any(String.class), any(EdcContractDefinition.class),
                 any())).thenThrow( HttpClientErrorException.create("Surprise", HttpStatus.INTERNAL_SERVER_ERROR, "", null, null, null));
 
         assertThrows(CreateEdcContractDefinitionException.class,
                 () -> service.createContractDefinition(assetId, policyId));
     }
 
+    @Test
+    void givenGetContractDefinitions_thenReturnContractDefinitions() {
+        // given
+        when(edcConfiguration.getControlplane()).thenReturn(controlplaneConfig);
+        when(controlplaneConfig.getEndpoint()).thenReturn(endpointConfig);
+        when(endpointConfig.getContractDefinition()).thenReturn("/management/v2/contractdefinitions");
+        when(restTemplate.exchange(any(String.class), any(HttpMethod.class),
+                any(), any(ParameterizedTypeReference.class))).thenReturn(ResponseEntity.of(
+                Optional.of(List.of(EdcContractDefinition.builder().accessPolicyId("").contractPolicyId("").build()))));
+
+        //when
+        final ResponseEntity<List<EdcContractDefinition>> contractDefinitions = service.getContractDefinitions(
+                new QuerySpec());
+        //then
+        assertThat(contractDefinitions.getBody()).isNotEmpty();
+
+    }
+
+    @Test
+    void givenDeleteContractDefinition_thenCallDeletionEndpoint() {
+        // given
+        when(edcConfiguration.getControlplane()).thenReturn(controlplaneConfig);
+        when(controlplaneConfig.getEndpoint()).thenReturn(endpointConfig);
+        when(endpointConfig.getContractDefinition()).thenReturn("/management/v2/contractdefinitions");
+
+        //when
+        service.deleteContractDefinition("");
+
+        //then
+        Mockito.verify(restTemplate).delete(anyString(), anyString());
+
+    }
+
+    @Test
+    void testCreateContractDefinitionResponse() throws IOException, JSONException {
+        //GIVEN
+        String jsonResponse = """
+                [
+                	{
+                		"@id": "d355a2d5-bb3c-4fb1-b7a5-efa94f48ce73",
+                		"@type": "ContractDefinition",
+                		"accessPolicyId": "default-policy",
+                		"contractPolicyId": "default-policy",
+                		"assetsSelector": {
+                			"@type": "Criterion",
+                			"operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
+                			"operator": "=",
+                			"operandRight": "02d6977e-b71c-4873-9294-a9a15e05abb7"
+                		},
+                		"@context": {
+                			"edc": "https://w3id.org/edc/v0.0.1/ns/"
+                		}
+                	}
+                ]
+                """;
+        //WHEN
+        List<EdcContractDefinition> responseObj = objectMapper.readValue(jsonResponse, TypeFactory.defaultInstance().constructCollectionType(List.class, EdcContractDefinition.class));
+
+        //THEN
+        JSONAssert.assertEquals(jsonResponse, objectMapper.writeValueAsString(responseObj), false);
+    }
 }


### PR DESCRIPTION
…ition and deleteContractDefinition functionality

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
