### PR TITLE
fix(e2e-tests):[#538] exclude the new detail field rootCauses from th…

### DIFF
--- a/irs-cucumber-tests/src/test/java/org/eclipse/tractusx/irs/cucumber/E2ETestStepDefinitionsForJobApi.java
+++ b/irs-cucumber-tests/src/test/java/org/eclipse/tractusx/irs/cucumber/E2ETestStepDefinitionsForJobApi.java
@@ -384,7 +384,7 @@ public class E2ETestStepDefinitionsForJobApi {
             final List<Tombstone> expectedTombstones = getExpectedTombstones(fileName);
             assertThat(actualTombstones).hasSameSizeAs(expectedTombstones)
                                         .usingRecursiveFieldByFieldElementComparatorIgnoringFields(
-                                                "processingError.lastAttempt")
+                                                "processingError.lastAttempt", "processingError.rootCauses")
                                         .containsAll(expectedTombstones);
         }
     }


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

- exclude newly added field rootCauses from check (does not change test logic) in context of #538 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
