### PR TITLE
chore(trg): update .tractusx metadata file for TRG 1.08

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,4 +1,5 @@
 product: "Item Relationship Service"
 leadingRepository: "https://github.com/eclipse-tractusx/item-relationship-service"
 repositories: []
-
+openApiSpecs:
+- "https://raw.githubusercontent.com/eclipse-tractusx/item-relationship-service/main/docs/src/api/irs-api.yaml"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR addresses the new state of TRG 1.08.

- Added property in `.tractusx` metadata file to reference OpenAPI spec since the spec does not reside in the path `/docs/api` required by TRG 1.08

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
