### PR TITLE
chore(documentation): [#639] deprecation note for `GET /irs/policies`

### DIFF
--- a/docs/src/api/irs-api.yaml
+++ b/docs/src/api/irs-api.yaml
@@ -794,6 +794,7 @@ paths:
       - Item Relationship Service
   /irs/policies:
     get:
+      deprecated: true
       description: Lists the registered policies that should be accepted in EDC negotiation.
       operationId: getAllowedPoliciesByBpn
       parameters:
@@ -860,6 +861,7 @@ paths:
       security:
       - api_key: []
       summary: Lists the registered policies that should be accepted in EDC negotiation.
+        (This method is DEPRECATED in favor of `/policies/paged`)
       tags:
       - Policy Store API
     post:

--- a/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/controllers/PolicyStoreController.java
+++ b/irs-policy-store/src/main/java/org/eclipse/tractusx/irs/policystore/controllers/PolicyStoreController.java
@@ -165,7 +165,8 @@ public class PolicyStoreController {
     }
 
     @Operation(operationId = "getAllowedPoliciesByBpn",
-               summary = "Lists the registered policies that should be accepted in EDC negotiation.",
+               summary = "Lists the registered policies that should be accepted in EDC negotiation. "
+                         + "(This method is DEPRECATED in favor of `/policies/paged`)", deprecated = true,
                security = @SecurityRequirement(name = API_KEY), tags = { POLICY_API_TAG },
                description = "Lists the registered policies that should be accepted in EDC negotiation.")
     @ApiResponses(value = { @ApiResponse(responseCode = "200",
@@ -192,11 +193,13 @@ public class PolicyStoreController {
     @GetMapping("/policies")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("hasAuthority('" + IrsRoles.ADMIN_IRS + "')")
+    @Deprecated(forRemoval = true)
     public Map<String, List<PolicyResponse>> getPolicies(//
             @RequestParam(required = false) //
             @ValidListOfBusinessPartnerNumbers(allowDefault = true) //
             @Parameter(description = "List of business partner numbers. "
-                    + "This may also contain the value \"default\" in order to query the default policies.") //
+                                     + "This may also contain the value \"default\" in order to query the default policies.")
+            //
             final List<String> businessPartnerNumbers //
     ) {
 
@@ -263,7 +266,7 @@ public class PolicyStoreController {
     @GetMapping("/policies/paged")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Find registered policies that should be accepted in EDC negotiation "
-            + "(with filtering, sorting and paging).", //
+                         + "(with filtering, sorting and paging).", //
                description = """
                        Fetch a page of policies with options to filter and sort.
                        \s
@@ -326,7 +329,8 @@ public class PolicyStoreController {
             @RequestParam(required = false) //
             @ValidListOfBusinessPartnerNumbers(allowDefault = true) //
             @Parameter(name = "businessPartnerNumbers", description = "List of business partner numbers. "
-                    + "This may also contain the value \"default\" in order to query the default policies.") //
+                                                                      + "This may also contain the value \"default\" in order to query the default policies.")
+            //
             final List<String> businessPartnerNumbers) {
 
         if (pageable.getPageSize() > MAX_PAGE_SIZE) {


### PR DESCRIPTION
## Description

- deprecation note for `GET /irs/policies` (in future the paged endpoint should be used), see #639

![grafik](https://github.com/user-attachments/assets/863ac70e-36e5-4d17-aaf4-a201c7ad78b7)


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
