### PR TITLE
chore(workflows): replace hardcoded GH repo URL with variables

### DIFF
--- a/.github/workflows/cucumber-integration-test-UMBRELLA.yaml
+++ b/.github/workflows/cucumber-integration-test-UMBRELLA.yaml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   execute-e2e-tests:
-    runs-on: tractusx-runner
+    runs-on: "${{ github.repository == 'eclipse-tractusx/item-relationship-service' && 'tractusx-runner' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,7 @@ jobs:
 
           # insert new comparison below uppermost one
           sed -i "$((latest_comparison_url_line_number+1)) s|^|[${{ inputs.irs-version }}]: \
-          https://github.com/eclipse-tractusx/item-relationship-service/compare/$previous_irs_version...${{ inputs.irs-version }}\n|" ${{ env.CHANGELOG_PATH }}        
+          ${{ github.server_url }}/${{ github.repository }}/compare/$previous_irs_version...${{ inputs.irs-version }}\n|" ${{ env.CHANGELOG_PATH }}        
 
           # replace placeholder
           placeholder_line_number=$(cat -n ${{ env.CHANGELOG_PATH }} | grep -Eoi "[0-9]+.## \[Unreleased\]" | grep -Eo "[0-9]+")

--- a/.github/workflows/tavern-UMBRELLA.yml
+++ b/.github/workflows/tavern-UMBRELLA.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: tractusx-runner
+    runs-on: "${{ github.repository == 'eclipse-tractusx/item-relationship-service' && 'tractusx-runner' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description
- replace hardcoded GH repo URL with variables
- choose GH runner for umbrella tests dynamically, depending on the repo

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
