### PR TITLE
chore(docs): add sequence diagrams for improvements in scalability

### DIFF
--- a/docs/src/uml-diagrams/runtime-view/scaling-edc-processing.puml
+++ b/docs/src/uml-diagrams/runtime-view/scaling-edc-processing.puml
@@ -1,0 +1,35 @@
+@startuml
+skinparam monochrome true
+skinparam shadowing false
+skinparam defaultFontName "Architects daughter"
+
+
+autonumber "<b>[00]"
+
+participant "EDC Client" as IRS
+participant "EDC Cache" as edc_cache
+participant "EDC" as EDC
+
+IRS -> EDC: Request Contract Offers {filter": "type=digitalTwinRegistry"}
+IRS <-- EDC: Contract Offer
+
+IRS -> edc_cache: get EDR Token
+
+group EDC negotiation and transfer process
+    rnote right edc_cache
+        replace traditional token negotiation with EDR API
+        this makes reuse of existing negotiations more efficient
+    end note
+
+    edc_cache -> EDC: Negotiate Contract for Offer
+    edc_cache <-- EDC: Contract Negotiation (Contract Agreement ID))
+
+    edc_cache -> EDC: Initiate Transfer with Agreement ID
+    edc_cache <-- EDC: Transfer Process ID
+
+    edc_cache <-- EDC : EDR Token callback
+end
+
+IRS <-- edc_cache: EDR Token
+
+@enduml

--- a/docs/src/uml-diagrams/runtime-view/scaling-job-batch-processing.puml
+++ b/docs/src/uml-diagrams/runtime-view/scaling-job-batch-processing.puml
@@ -19,8 +19,8 @@ BatchController --> CreationBatchService: create batches
 CreationBatchService -> CreationBatchService: split into parallel executable working packages
 
 rnote right
-    Currently this is not limited.
-    Limit of e.g. 5 jobs in parallel needs to be added.
+    As is: parallel processes are not limited
+    To be: limit of e.g. 5 jobs in parallel
 end note
 
 loop

--- a/docs/src/uml-diagrams/runtime-view/scaling-job-batch-processing.puml
+++ b/docs/src/uml-diagrams/runtime-view/scaling-job-batch-processing.puml
@@ -1,0 +1,34 @@
+@startuml
+skinparam monochrome true
+skinparam shadowing false
+skinparam defaultFontName "Architects daughter"
+autonumber "<b>[00]"
+
+actor IrsApiConsumer
+
+
+box "IRS" #LightGrey
+
+IrsApiConsumer -> BatchController : POST /irs/orders
+rnote left
+    200k digital twin ids
+end note
+IrsApiConsumer <- BatchController : order id
+
+BatchController --> CreationBatchService: create batches
+CreationBatchService -> CreationBatchService: split into parallel executable working packages
+
+rnote right
+    Currently this is not limited.
+    Limit of e.g. 5 jobs in parallel needs to be added.
+end note
+
+loop
+    rnote right CreationBatchService
+        sequentially
+    end note
+    CreationBatchService -> JobEventLinkedQueueListener: execute working packages
+    JobEventLinkedQueueListener --> IrsApiConsumer: callback on completed batch
+end
+
+@enduml

--- a/docs/src/uml-diagrams/runtime-view/scaling-job-processing.puml
+++ b/docs/src/uml-diagrams/runtime-view/scaling-job-processing.puml
@@ -1,0 +1,36 @@
+@startuml
+skinparam monochrome true
+skinparam shadowing false
+skinparam defaultFontName "Architects daughter"
+autonumber "<b>[00]"
+
+actor IrsApiConsumer
+
+
+box "IRS" #LightGrey
+
+IrsApiConsumer -> IrsController : POST /irs/jobs
+rnote right IrsApiConsumer
+    id instead of globalAssetId
+end rnote
+IrsApiConsumer <- IrsController : job id
+
+participant "blackbox IRS processing" as irs_process
+
+IrsController -> irs_process
+irs_process -> DTR: get twin by id
+rnote right irs_process
+1 call instead of 2
+end rnote
+irs_process <- DTR: twin
+
+irs_process -> irs_process: globalAssetId of twin is saved in job response
+rnote right irs_process
+   As is: the id with which the Job was started is saved as globalAssetId in the job
+   To be: Job contains the globalAssetId instead of the id
+end rnote
+
+IrsApiConsumer -> IrsController : GET /irs/jobs/<id>
+IrsApiConsumer <- IrsController : job
+
+@enduml


### PR DESCRIPTION
## Description
Added 3 sequence diagrams to illustrate points of improvements in the IRS Job process in regards to scalability.
They focus on internal IRS processes, as well as communication with the Digitial Twin Registry (DTR) and Eclipse Dataspace Connector (EDC).

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
