### PR TITLE
chore: [TRX-96] Adapt-Discovery-flow (bpnl) (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 
 ## [Unreleased]
 
+### Changed 
+
+- Added the discovery type configurable, with a default value of bpnl in (ConnectorEndpointsService) (#12)
+
 ## [5.4.1] - 2024-08-19
 
 ### Fixed

--- a/charts/item-relationship-service/CHANGELOG.md
+++ b/charts/item-relationship-service/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added the discovery type configurable (discovery.type) default value as bpnl. (#12). 
+
 ## [7.4.1] - 2024-08-19
 
 ### Changed

--- a/charts/item-relationship-service/templates/configmap-spring-app-config.yaml
+++ b/charts/item-relationship-service/templates/configmap-spring-app-config.yaml
@@ -80,6 +80,7 @@ data:
       discovery:
         oAuthClientId: {{ .Values.discovery.oAuthClientId | default "discovery" }} # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
         discoveryFinderUrl: {{ tpl (.Values.discovery.discoveryFinderUrl | default "") . | quote }} # The endpoint to discover EDC endpoints to a particular BPN.
+        type: {{ .Values.discovery.type | default "bpnl" }} # Type to discover EDC of type "bpnl".
 
     semanticshub:
       url: {{ tpl (.Values.semanticshub.url | default "") . | quote }}

--- a/charts/item-relationship-service/values.yaml
+++ b/charts/item-relationship-service/values.yaml
@@ -132,6 +132,7 @@ digitalTwinRegistry:
 discovery:
   oAuthClientId: discovery  # ID of the OAuth2 client registration to use, see config spring.security.oauth2.client
   discoveryFinderUrl:  # "https://<discovery-finder-url>
+  type: "bpnl"  # discovery type to find bpnl type in EDC discovery
 
 semanticshub:
   url:  # https://<semantics-hub-url>

--- a/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RegistryConfiguration.java
+++ b/irs-api/src/main/java/org/eclipse/tractusx/irs/configuration/RegistryConfiguration.java
@@ -97,9 +97,11 @@ public class RegistryConfiguration {
     @Bean
     public ConnectorEndpointsService connectorEndpointsService(
             @Qualifier(RestTemplateConfig.DTR_REST_TEMPLATE) final RestTemplate dtrRestTemplate,
-            @Value("${digitalTwinRegistry.discovery.discoveryFinderUrl:}") final String finderUrl) {
-        return new ConnectorEndpointsService(discoveryFinderClient(dtrRestTemplate, finderUrl));
+            @Value("${digitalTwinRegistry.discovery.discoveryFinderUrl:}") final String finderUrl,
+            @Value("${digitalTwinRegistry.discovery.type:}") final String discoveryType) {
+        return new ConnectorEndpointsService(discoveryFinderClient(dtrRestTemplate, finderUrl), discoveryType);
     }
+
 
     @Bean
     public DiscoveryFinderClient discoveryFinderClient(

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DefaultConfiguration.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/DefaultConfiguration.java
@@ -110,8 +110,9 @@ public class DefaultConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = CONFIG_PREFIX, name = CONFIG_FIELD_TYPE, havingValue = CONFIG_VALUE_DECENTRAL)
-    public ConnectorEndpointsService connectorEndpointsService(final DiscoveryFinderClient discoveryFinderClient) {
-        return new ConnectorEndpointsService(discoveryFinderClient);
+    public ConnectorEndpointsService connectorEndpointsService(final DiscoveryFinderClient discoveryFinderClient,
+            @Value("${digitalTwinRegistryClient.discovery.type:}") final String discoveryType) {
+        return new ConnectorEndpointsService(discoveryFinderClient, discoveryType);
     }
 
     @Bean

--- a/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/ConnectorEndpointsService.java
+++ b/irs-registry-client/src/main/java/org/eclipse/tractusx/irs/registryclient/discovery/ConnectorEndpointsService.java
@@ -43,6 +43,7 @@ public class ConnectorEndpointsService {
 
     private final DiscoveryFinderClient discoveryFinderClient;
     private static final String CONNECTOR_ENDPOINT_SERVICE_CACHE_NAME = "connector_endpoint_service_cache";
+    private final String discoveryType;
 
     /**
      * Get EDCs for BPN.
@@ -60,7 +61,7 @@ public class ConnectorEndpointsService {
 
         log.info("Requesting connector endpoints for BPN {}", bpn);
 
-        final var onlyBpn = new DiscoveryFinderRequest(List.of("bpn"));
+        final var onlyBpn = new DiscoveryFinderRequest(List.of(discoveryType));
         final var discoveryEndpoints = discoveryFinderClient.findDiscoveryEndpoints(onlyBpn).endpoints();
         final var endpoints = discoveryEndpoints.stream()
                                                 .flatMap(

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/DefaultConfigurationTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/DefaultConfigurationTest.java
@@ -64,7 +64,7 @@ class DefaultConfigurationTest {
     void decentralDigitalTwinRegistryService() {
         final EdcSubmodelFacade facadeMock = mock(EdcSubmodelFacade.class);
         final var service = testee.decentralDigitalTwinRegistryService(
-                testee.connectorEndpointsService(testee.discoveryFinderClient(new RestTemplate(), "finder")),
+                testee.connectorEndpointsService(testee.discoveryFinderClient(new RestTemplate(), "finder"), "bpnl"),
                 testee.endpointDataForConnectorsService(facadeMock),
                 testee.decentralDigitalTwinRegistryClient(new RestTemplate(), descriptorTemplate, shellLookupTemplate),
                 edcConfiguration);

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryServiceWiremockTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/decentral/DecentralDigitalTwinRegistryServiceWiremockTest.java
@@ -93,7 +93,7 @@ class DecentralDigitalTwinRegistryServiceWiremockTest {
         final RestTemplate restTemplate = restTemplateProxy(PROXY_SERVER_HOST, wireMockRuntimeInfo.getHttpPort());
 
         final var discoveryFinderClient = new DiscoveryFinderClientImpl(DISCOVERY_FINDER_URL, restTemplate);
-        final var connectorEndpointsService = new ConnectorEndpointsService(discoveryFinderClient);
+        final var connectorEndpointsService = new ConnectorEndpointsService(discoveryFinderClient, "bpnl");
         final var endpointDataForConnectorsService = new EndpointDataForConnectorsService(
                 edcEndpointReferenceRetrieverMock);
         final var decentralDigitalTwinRegistryClient = new DecentralDigitalTwinRegistryClient(restTemplate,

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/ConnectorEndpointsServiceTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/ConnectorEndpointsServiceTest.java
@@ -36,7 +36,7 @@ import org.mockito.Mockito;
 class ConnectorEndpointsServiceTest {
 
     private final DiscoveryFinderClient essDiscoveryFinderClient = Mockito.mock(DiscoveryFinderClient.class);
-    private final ConnectorEndpointsService service = new ConnectorEndpointsService(essDiscoveryFinderClient);
+    private final ConnectorEndpointsService service = new ConnectorEndpointsService(essDiscoveryFinderClient, "bpnl" );
 
     @Test
     void shouldFindConnectorEndpoints() {

--- a/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderClientImplTest.java
+++ b/irs-registry-client/src/test/java/org/eclipse/tractusx/irs/registryclient/discovery/DiscoveryFinderClientImplTest.java
@@ -61,7 +61,7 @@ class DiscoveryFinderClientImplTest {
             final DiscoveryResponse mockResponse = new DiscoveryResponse(
                     List.of(new DiscoveryEndpoint("test-endpoint", "desc", "test-endpoint-addr", "docs", "resId")));
 
-            final var request = new DiscoveryFinderRequest(List.of("bpn"));
+            final var request = new DiscoveryFinderRequest(List.of("bpnl"));
             when(restTemplate.postForObject(DISCOVERY_FINDER_URL, request, DiscoveryResponse.class)).thenReturn(
                     mockResponse);
 

--- a/local/deployment/full-irs/subcharts/discovery/templates/configmap.yaml
+++ b/local/deployment/full-irs/subcharts/discovery/templates/configmap.yaml
@@ -101,16 +101,16 @@ data:
   bpn_discovery_service_response.json: |-
     {
       "bpns": [
-        {"type": "bpn","key": ".*","value": "BPNL00000000BJTL","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003AVTH","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003AXS3","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003AYRE","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003AZQP","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003B0Q0","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003B2OM","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003B3NX","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003B5MJ","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003B5MJ","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
-        {"type": "bpn","key": ".*","value": "BPNL00000003CSGV","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"}
+        {"type": "bpnl","key": ".*","value": "BPNL00000000BJTL","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003AVTH","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003AXS3","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003AYRE","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003AZQP","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003B0Q0","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003B2OM","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003B3NX","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003B5MJ","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003B5MJ","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"},
+        {"type": "bpnl","key": ".*","value": "BPNL00000003CSGV","resourceId": "1ca6f9b5-8e1d-422a-8541-9bb2cf5fe485"}
       ]
     }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
The EDC discovery flow to be changed from type “bpn” to “bpnl”, and this parameter to be configurable in the future.

## Motivation

The EDC discovery flow works in the Cofinity-X system environment and could be easily adapted in the future.


## Changes

<!--List the key changes made in this pull request. Use bullet points for clarity. -->

- Made the discovery type configurable, with a default value of bpnl for both Traceability and IRS.
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
