### PR TITLE
fix(open-api): add different api version to provide them via api hub

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -3,3 +3,6 @@ leadingRepository: "https://github.com/eclipse-tractusx/item-relationship-servic
 repositories: []
 openApiSpecs:
 - "https://raw.githubusercontent.com/eclipse-tractusx/item-relationship-service/main/docs/src/api/irs-api.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/item-relationship-service/refs/tags/7.0.1/docs/src/api/irs-api.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/item-relationship-service/refs/tags/6.0.1/docs/src/api/irs-api.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/item-relationship-service/refs/tags/5.4.0/docs/src/api/irs-api.yaml"


### PR DESCRIPTION
## Description

This PR adds more version for the api  -> so the api-hub can provide them [here](https://eclipse-tractusx.github.io/api-hub/item-relationship-service/)

Some older KIT Version reference older API Version and until now, they are not available -> This PR changes the situation

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
